### PR TITLE
backstop: emitter: have backstop module define backstop token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ build:
 	cargo build --target wasm32-unknown-unknown --release -p b-token
 	cargo build --target wasm32-unknown-unknown --release -p oracle
 	cargo build --target wasm32-unknown-unknown --release -p mock-blend-oracle
-	cargo build --target wasm32-unknown-unknown --release -p emitter
 	cargo build --target wasm32-unknown-unknown --release -p pool-factory
 	cargo build --target wasm32-unknown-unknown --release -p mock-pool-factory
 	cargo build --target wasm32-unknown-unknown --release -p backstop-module
+	cargo build --target wasm32-unknown-unknown --release -p emitter
 	cargo build --target wasm32-unknown-unknown --release -p lending-pool
 	cd target/wasm32-unknown-unknown/release/ && \
 		for i in *.wasm ; do \

--- a/backstop-module/src/constants.rs
+++ b/backstop-module/src/constants.rs
@@ -1,6 +1,3 @@
-/// The address of the backstop token
-pub const BACKSTOP_TOKEN: [u8; 32] = [222; 32]; // TODO: Use actual token bytes
-
 // The address of the Blend Pool Factory
 pub const POOL_FACTORY: [u8; 32] = [101; 32]; // TODO: Use the actual pool factory address
 

--- a/backstop-module/src/errors.rs
+++ b/backstop-module/src/errors.rs
@@ -10,5 +10,6 @@ pub enum BackstopError {
     InvalidRewardZoneEntry = 4,
     NotAuthorized = 5,
     InsufficientFunds = 6,
+    AlreadyInitialized = 7,
     NotPool = 10,
 }

--- a/backstop-module/src/storage.rs
+++ b/backstop-module/src/storage.rs
@@ -31,11 +31,36 @@ pub enum BackstopDataKey {
     RewardZone,
     PoolEPS(BytesN<32>),
     PoolEmis(BytesN<32>),
+    BckstpTkn,
 }
 
 /****************************
 **         Storage         **
 ****************************/
+
+/********** Backstop Token **********/
+
+/// Fetch the backstop token
+pub fn get_backstop_token(e: &Env) -> BytesN<32> {
+    e.storage()
+        .get::<BackstopDataKey, BytesN<32>>(&BackstopDataKey::BckstpTkn)
+        .unwrap()
+        .unwrap()
+}
+
+/// Checks if a backstop token is set for the backstop
+pub fn has_backstop_token(e: &Env) -> bool {
+    e.storage().has(&BackstopDataKey::BckstpTkn)
+}
+
+/// Set the backstop token
+///
+/// ### Arguments
+/// * `token_address` - The address of the new backstop token
+pub fn set_backstop_token(e: &Env, token_address: &BytesN<32>) {
+    e.storage()
+        .set::<BackstopDataKey, BytesN<32>>(&BackstopDataKey::BckstpTkn, token_address);
+}
 
 /********** User Shares **********/
 

--- a/backstop-module/tests/test_backstop.rs
+++ b/backstop-module/tests/test_backstop.rs
@@ -23,6 +23,7 @@ fn test_backstop_happy_path() {
     let backstop = Address::from_contract_id(&e, &backstop_addr);
     let token_addr = BytesN::from_array(&e, &[222; 32]);
     let token_client = create_token_from_id(&e, &token_addr, &bombadil);
+    backstop_client.initialize(&token_addr);
 
     e.ledger().set(LedgerInfo {
         timestamp: 0,

--- a/backstop-module/tests/test_distribute_claim.rs
+++ b/backstop-module/tests/test_distribute_claim.rs
@@ -6,9 +6,7 @@ use soroban_sdk::{
 };
 
 mod common;
-use crate::common::{
-    create_backstop_module, create_mock_pool_factory, create_token_from_id, BackstopError,
-};
+use crate::common::{create_backstop_module, create_mock_pool_factory, create_token_from_id};
 
 #[test]
 fn test_backstop_distribution_and_claim_happy_path() {
@@ -22,6 +20,7 @@ fn test_backstop_distribution_and_claim_happy_path() {
     let backstop = Address::from_contract_id(&e, &backstop_addr);
     let token_addr = BytesN::from_array(&e, &[222; 32]);
     let token_client = create_token_from_id(&e, &token_addr, &bombadil);
+    backstop_client.initialize(&token_addr);
 
     let pool_1 = generate_contract_id(&e); // in reward zone
     let pool_1_id = Address::from_contract_id(&e, &pool_1);

--- a/backstop-module/tests/test_donate.rs
+++ b/backstop-module/tests/test_donate.rs
@@ -20,6 +20,7 @@ fn test_donate_happy_path() {
     let backstop = Address::from_contract_id(&e, &backstop_addr);
     let token_addr = BytesN::from_array(&e, &[222; 32]);
     let token_client = create_token_from_id(&e, &token_addr, &bombadil);
+    backstop_client.initialize(&token_addr);
 
     let pool_1 = generate_contract_id(&e);
     let pool_2 = generate_contract_id(&e);

--- a/backstop-module/tests/test_draw.rs
+++ b/backstop-module/tests/test_draw.rs
@@ -22,6 +22,7 @@ fn test_draw_happy_path() {
     let backstop = Address::from_contract_id(&e, &backstop_addr);
     let token_addr = BytesN::from_array(&e, &[222; 32]);
     let token_client = create_token_from_id(&e, &token_addr, &bombadil);
+    backstop_client.initialize(&token_addr);
 
     let pool_1 = generate_contract_id(&e);
     let pool_2 = generate_contract_id(&e);
@@ -84,6 +85,7 @@ fn test_draw_not_pool() {
     let backstop = Address::from_contract_id(&e, &backstop_addr);
     let token_addr = BytesN::from_array(&e, &[222; 32]);
     let token_client = create_token_from_id(&e, &token_addr, &bombadil);
+    backstop_client.initialize(&token_addr);
 
     let pool_1 = generate_contract_id(&e);
     let pool_2 = generate_contract_id(&e);

--- a/emitter/src/constants.rs
+++ b/emitter/src/constants.rs
@@ -1,5 +1,2 @@
-/// The address of the backstop token
-pub const BACKSTOP_TOKEN: [u8; 32] = [222; 32]; // TODO: Use actual token bytes
-
 /// Fixed-point scalar for 7 decimal numbers
 pub const SCALAR_7: i128 = 1_0000000;

--- a/emitter/src/dependencies/backstop.rs
+++ b/emitter/src/dependencies/backstop.rs
@@ -1,0 +1,3 @@
+use soroban_sdk::contractimport;
+
+contractimport!(file = "../target/wasm32-unknown-unknown/release/backstop_module.wasm");

--- a/emitter/src/dependencies/mod.rs
+++ b/emitter/src/dependencies/mod.rs
@@ -2,3 +2,8 @@ mod token;
 pub use token::Client as TokenClient;
 #[cfg(any(test, feature = "testutils"))]
 pub use token::WASM as TOKEN_WASM;
+
+mod backstop;
+pub use backstop::Client as BackstopClient;
+#[cfg(any(test, feature = "testutils"))]
+pub use backstop::{BackstopDataKey, WASM as BACKSTOP_WASM};

--- a/emitter/src/emitter.rs
+++ b/emitter/src/emitter.rs
@@ -2,7 +2,7 @@ use crate::{
     constants::SCALAR_7, dependencies::TokenClient, errors::EmitterError,
     lp_reader::get_lp_blend_holdings, storage,
 };
-use soroban_sdk::{contractimpl, symbol, Address, BytesN, Env};
+use soroban_sdk::{Address, Env};
 
 /// Perform a distribution
 pub fn execute_distribute(e: &Env, backstop: &Address) -> Result<i128, EmitterError> {
@@ -44,11 +44,4 @@ pub fn execute_swap_backstop(e: &Env, new_backstop: Address) -> Result<(), Emitt
 
     storage::set_backstop(e, &new_backstop);
     Ok(())
-}
-
-// ****** Helpers ********
-
-pub fn get_blend_token_client(e: &Env) -> TokenClient {
-    let id = storage::get_blend_id(e);
-    TokenClient::new(e, &id)
 }

--- a/emitter/src/storage.rs
+++ b/emitter/src/storage.rs
@@ -8,6 +8,8 @@ use soroban_sdk::{contracttype, Address, BytesN, Env};
 pub enum EmitterDataKey {
     // The address of the backstop module contract
     Backstop,
+    /// TODO: Delete after address <-> bytesN support,
+    BstopId,
     // The address of the blend token contract
     BlendId,
     // The address of the blend lp token contract
@@ -18,7 +20,7 @@ pub enum EmitterDataKey {
 
 /********** Backstop **********/
 
-/// Fetch the current backstop Identifier
+/// Fetch the current backstop
 ///
 /// Returns current backstop module contract address
 pub fn get_backstop(e: &Env) -> Address {
@@ -30,7 +32,7 @@ pub fn get_backstop(e: &Env) -> Address {
 /// Set a new backstop
 ///
 /// ### Arguments
-/// * `new_backstop` - The Identifier for the new backstop
+/// * `new_backstop` - The id for the new backstop
 pub fn set_backstop(e: &Env, new_backstop: &Address) {
     e.storage()
         .set::<EmitterDataKey, Address>(&EmitterDataKey::Backstop, &new_backstop);
@@ -39,7 +41,7 @@ pub fn set_backstop(e: &Env, new_backstop: &Address) {
 /// Check if a backstop has been set
 ///
 /// Returns true if a backstop has been set
-pub fn is_backstop_set(e: &Env) -> bool {
+pub fn has_backstop(e: &Env) -> bool {
     e.storage().has(&EmitterDataKey::Backstop)
 }
 
@@ -61,10 +63,10 @@ pub fn set_blend_id(e: &Env, blend_id: &BytesN<32>) {
         .set::<EmitterDataKey, BytesN<32>>(&EmitterDataKey::BlendId, &blend_id);
 }
 
-/// Fetch the lp token address
+/// Fetch the backstop token address
 ///
 /// Returns the blend lp token address
-pub fn get_blend_lp_id(e: &Env) -> BytesN<32> {
+pub fn get_backstop_token_id(e: &Env) -> BytesN<32> {
     e.storage()
         .get_unchecked(&EmitterDataKey::BlendLPId)
         .unwrap()
@@ -74,7 +76,7 @@ pub fn get_blend_lp_id(e: &Env) -> BytesN<32> {
 ///
 /// ### Arguments
 /// * `blend_lp_id` - The blend lp token address
-pub fn set_blend_lp_id(e: &Env, blend_lp_id: &BytesN<32>) {
+pub fn set_backstop_token_id(e: &Env, blend_lp_id: &BytesN<32>) {
     e.storage()
         .set::<EmitterDataKey, BytesN<32>>(&EmitterDataKey::BlendLPId, blend_lp_id);
 }

--- a/emitter/tests/common/mod.rs
+++ b/emitter/tests/common/mod.rs
@@ -14,6 +14,13 @@ mod emitter {
 
 pub use emitter::{Client as EmitterClient, EmitterError};
 
+mod backstop {
+    soroban_sdk::contractimport!(
+        file = "../target/wasm32-unknown-unknown/release/backstop_module.wasm"
+    );
+}
+pub use backstop::Client as BackstopClient;
+
 pub fn generate_contract_id(e: &Env) -> BytesN<32> {
     let mut id: [u8; 32] = Default::default();
     thread_rng().fill_bytes(&mut id);
@@ -30,4 +37,10 @@ pub fn create_wasm_emitter(e: &Env) -> (BytesN<32>, EmitterClient) {
     let contract_id = generate_contract_id(e);
     e.register_contract_wasm(&contract_id, emitter::WASM);
     (contract_id.clone(), EmitterClient::new(e, &contract_id))
+}
+
+pub fn create_backstop(e: &Env) -> (BytesN<32>, BackstopClient) {
+    let contract_id = generate_contract_id(e);
+    e.register_contract_wasm(&contract_id, backstop::WASM);
+    (contract_id.clone(), BackstopClient::new(e, &contract_id))
 }


### PR DESCRIPTION
Update the backstop token address to be stored on the backstop module.

This allows the emitter to consume a new backstop token address if the backstop is swapped to a new one, providing a difficult, but possible, update mechanism for the LP token.