### PR TITLE
Remove unused parens

### DIFF
--- a/backstop-module/src/contract.rs
+++ b/backstop-module/src/contract.rs
@@ -213,7 +213,7 @@ impl BackstopModuleTrait for BackstopModule {
 
         e.events().publish(
             (Symbol::new(&e, "dequeue_withdrawal"), pool_address, from),
-            (amount),
+            amount,
         );
     }
 
@@ -301,7 +301,7 @@ impl BackstopModuleTrait for BackstopModule {
 
         backstop::execute_donate(&e, &from, &pool_address, amount);
         e.events()
-            .publish((Symbol::new(&e, "donate"), pool_address, from), (amount));
+            .publish((Symbol::new(&e, "donate"), pool_address, from), amount);
     }
 }
 


### PR DESCRIPTION
I realize it's probably a stylistic choice to put parens here, but new versions of the compiler have started complaining about unused parens, probably one of the lints [promoted from clippy directly into rustc](https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html#uplifted-lints-from-clippy). These could also be annotated with `#[allow(unused_parens)]` if preferred.

Edit: maybe this is not a new lint.