### PR TITLE
Emitter: updated drop tracking

### DIFF
--- a/emitter/src/contract.rs
+++ b/emitter/src/contract.rs
@@ -58,8 +58,6 @@ impl Emitter for EmitterContract {
         storage::set_backstop(&e, &backstop);
         storage::set_blend_id(&e, &blnd_token_id);
         storage::set_last_fork(&e, 0); // We set the block 45 days in the past to allow for an immediate initial drop
-        storage::set_drop_status(&e, false);
-        // TODO: Determine if setting the last distro time here is appropriate, since it means tokens immediately start being distributed
         storage::set_last_distro_time(&e, &(e.ledger().timestamp() - 7 * 24 * 60 * 60));
     }
 

--- a/emitter/src/storage.rs
+++ b/emitter/src/storage.rs
@@ -122,7 +122,7 @@ pub fn get_drop_status(e: &Env, backstop: &Address) -> bool {
     e.storage()
         .instance()
         .get::<EmitterDataKey, bool>(&EmitterDataKey::Dropped(backstop.clone()))
-        .is_some()
+        .unwrap_or(false)
 }
 
 /// Set whether the emitter has performed the drop distribution or not for the current backstop

--- a/emitter/src/storage.rs
+++ b/emitter/src/storage.rs
@@ -19,8 +19,8 @@ pub enum EmitterDataKey {
     BlendLPId,
     // The last timestamp distribution was ran on
     LastDistro,
-    // The drop status for the current backstop
-    DropStatus,
+    // Stores the list of backstop addresses that have dropped
+    Dropped(Address),
     // The last block emissions were forked
     LastFork,
 }
@@ -118,21 +118,21 @@ pub fn set_last_distro_time(e: &Env, last_distro: &u64) {
 /// Get whether the emitter has performed the drop distribution or not for the current backstop
 ///
 /// Returns true if the emitter has dropped
-pub fn get_drop_status(e: &Env) -> bool {
+pub fn get_drop_status(e: &Env, backstop: &Address) -> bool {
     e.storage()
         .instance()
-        .get(&EmitterDataKey::DropStatus)
-        .unwrap_optimized()
+        .get::<EmitterDataKey, bool>(&EmitterDataKey::Dropped(backstop.clone()))
+        .is_some()
 }
 
 /// Set whether the emitter has performed the drop distribution or not for the current backstop
 ///
 /// ### Arguments
 /// * `new_status` - new drop status
-pub fn set_drop_status(e: &Env, new_status: bool) {
+pub fn set_drop_status(e: &Env, backstop: &Address) {
     e.storage()
         .instance()
-        .set::<EmitterDataKey, bool>(&EmitterDataKey::DropStatus, &new_status);
+        .set::<EmitterDataKey, bool>(&EmitterDataKey::Dropped(backstop.clone()), &true);
 }
 
 /// Get the last block an emission fork was executed


### PR DESCRIPTION
Changed how we track what drops have occurred to use a list of addresses instead of a bool status. 

Resolves: https://github.com/blend-capital/blend-contracts/issues/145