### PR TITLE
Pool: added new_admin auth requirement for admin swaps

### DIFF
--- a/pool/src/contract.rs
+++ b/pool/src/contract.rs
@@ -262,6 +262,7 @@ impl Pool for PoolContract {
         storage::extend_instance(&e);
         let admin = storage::get_admin(&e);
         admin.require_auth();
+        new_admin.require_auth();
 
         storage::set_admin(&e, &new_admin);
 

--- a/pool/src/pool/submit.rs
+++ b/pool/src/pool/submit.rs
@@ -193,7 +193,7 @@ mod tests {
         let (reserve_config, reserve_data) = testutils::default_reserve_meta();
         testutils::create_reserve(&e, &pool, &underlying_0, &reserve_config, &reserve_data);
 
-        let (underlying_1, underlying_1_client) = testutils::create_token_contract(&e, &bombadil);
+        let (underlying_1, _) = testutils::create_token_contract(&e, &bombadil);
         let (reserve_config, reserve_data) = testutils::default_reserve_meta();
         testutils::create_reserve(&e, &pool, &underlying_1, &reserve_config, &reserve_data);
 

--- a/test-suites/tests/test_pool.rs
+++ b/test-suites/tests/test_pool.rs
@@ -707,6 +707,20 @@ fn test_pool_config() {
             }
         )
     );
+    assert_eq!(
+        fixture.env.auths()[1],
+        (
+            new_admin.clone(),
+            AuthorizedInvocation {
+                function: AuthorizedFunction::Contract((
+                    pool_fixture.pool.address.clone(),
+                    Symbol::new(&fixture.env, "set_admin"),
+                    vec![&fixture.env, new_admin.to_val(),]
+                )),
+                sub_invocations: std::vec![]
+            }
+        )
+    );
     let event = vec![&fixture.env, fixture.env.events().all().last_unchecked()];
     assert_eq!(
         event,


### PR DESCRIPTION
set_auth() now requires auth from the new admin as well as the incumbent - this change is in accordance with issue 172