### PR TITLE
Constants

### DIFF
--- a/backstop/src/backstop/pool.rs
+++ b/backstop/src/backstop/pool.rs
@@ -86,7 +86,7 @@ pub fn require_pool_above_threshold(pool_backstop_data: &PoolBackstopData) -> bo
         .saturating_mul(bal_blnd)
         .saturating_mul(bal_usdc)
         .saturating_mul(SCALAR_7); // 10^7 * 10^7
-    saturating_pool_pc / threshold_pc >= 1_0000000
+    saturating_pool_pc / threshold_pc >= SCALAR_7
 }
 
 /// The pool's backstop balances

--- a/pool-factory/src/pool_factory.rs
+++ b/pool-factory/src/pool_factory.rs
@@ -7,6 +7,8 @@ use soroban_sdk::{
     Symbol, Val, Vec,
 };
 
+const SCALAR_9: u64 = 1_000_000_000;
+
 #[contract]
 pub struct PoolFactoryContract;
 
@@ -69,7 +71,7 @@ impl PoolFactory for PoolFactoryContract {
         let pool_init_meta = storage::get_pool_init_meta(&e);
 
         // verify backstop take rate is within [0,1) with 9 decimals
-        if backstop_take_rate >= 1_000_000_000 {
+        if backstop_take_rate >= SCALAR_9 {
             panic_with_error!(&e, PoolFactoryError::InvalidPoolInitArgs);
         }
 

--- a/pool/src/auctions/auction.rs
+++ b/pool/src/auctions/auction.rs
@@ -25,12 +25,12 @@ pub enum AuctionType {
 }
 
 impl AuctionType {
-    pub fn from_u32(value: u32) -> Self {
+    pub fn from_u32(e: &Env, value: u32) -> Self {
         match value {
             0 => AuctionType::UserLiquidation,
             1 => AuctionType::BadDebtAuction,
             2 => AuctionType::InterestAuction,
-            _ => panic!("internal error"),
+            _ => panic_with_error!(e, PoolError::BadRequest),
         }
     }
 }
@@ -54,7 +54,7 @@ pub struct AuctionData {
 /// If the auction is unable to be created
 pub fn create(e: &Env, auction_type: u32) -> AuctionData {
     let backstop = storage::get_backstop(e);
-    let auction_data = match AuctionType::from_u32(auction_type) {
+    let auction_data = match AuctionType::from_u32(e, auction_type) {
         AuctionType::UserLiquidation => {
             panic_with_error!(e, PoolError::BadRequest);
         }
@@ -131,7 +131,7 @@ pub fn fill(
 ) {
     let auction_data = storage::get_auction(e, &auction_type, user);
     let (to_fill_auction, remaining_auction) = scale_auction(e, &auction_data, percent_filled);
-    match AuctionType::from_u32(auction_type) {
+    match AuctionType::from_u32(e, auction_type) {
         AuctionType::UserLiquidation => {
             fill_user_liq_auction(e, pool, &to_fill_auction, user, filler_state)
         }

--- a/pool/src/auctions/user_liquidation_auction.rs
+++ b/pool/src/auctions/user_liquidation_auction.rs
@@ -52,7 +52,7 @@ pub fn create_user_liq_auction_data(
         .fixed_div_floor(position_data.liability_raw, oracle_scalar)
         .unwrap_optimized();
     let est_incentive = (SCALAR_7 - avg_cf.fixed_div_ceil(avg_lf, SCALAR_7).unwrap_optimized())
-        .fixed_div_ceil(2_0000000, SCALAR_7)
+        .fixed_div_ceil(2 * SCALAR_7, SCALAR_7)
         .unwrap_optimized()
         + SCALAR_7;
 
@@ -65,8 +65,8 @@ pub fn create_user_liq_auction_data(
     let mut est_withdrawn_collateral_pct = est_withdrawn_collateral
         .fixed_div_ceil(position_data.collateral_raw, oracle_scalar)
         .unwrap_optimized();
-    if est_withdrawn_collateral_pct > 1_0000000 {
-        est_withdrawn_collateral_pct = 1_0000000;
+    if est_withdrawn_collateral_pct > SCALAR_7 {
+        est_withdrawn_collateral_pct = SCALAR_7;
     }
 
     for (asset, amount) in user_state.positions.collateral.iter() {

--- a/pool/src/emissions/manager.rs
+++ b/pool/src/emissions/manager.rs
@@ -46,7 +46,7 @@ pub fn set_pool_emissions(e: &Env, res_emission_metadata: Vec<ReserveEmissionMet
         total_share += metadata.share;
     }
 
-    if total_share > 1_0000000 {
+    if total_share > SCALAR_7 as u64 {
         panic_with_error!(e, PoolError::BadRequest);
     }
 

--- a/pool/src/lib.rs
+++ b/pool/src/lib.rs
@@ -20,7 +20,7 @@ pub use auctions::{AuctionData, AuctionType};
 pub use contract::*;
 pub use emissions::ReserveEmissionMetadata;
 pub use errors::PoolError;
-pub use pool::{Positions, Request};
+pub use pool::{Positions, Request, RequestType};
 pub use storage::{
     AuctionKey, PoolConfig, PoolDataKey, PoolEmissionConfig, ReserveConfig, ReserveData,
     ReserveEmissionsConfig, ReserveEmissionsData, UserEmissionData, UserReserveKey,

--- a/pool/src/pool/health_factor.rs
+++ b/pool/src/pool/health_factor.rs
@@ -196,7 +196,7 @@ mod tests {
             assert_eq!(position_data.liability_base, 185_2368827);
             assert_eq!(position_data.collateral_raw, 350_3984567);
             assert_eq!(position_data.liability_raw, 148_0895061);
-            assert_eq!(position_data.scalar, 1_0000000);
+            assert_eq!(position_data.scalar, SCALAR_7);
         });
     }
 

--- a/pool/src/pool/interest.rs
+++ b/pool/src/pool/interest.rs
@@ -81,8 +81,9 @@ pub fn calc_accrual(
             .fixed_mul_floor(i128(config.reactivity), SCALAR_9)
             .unwrap_optimized();
         let next_ir_mod = ir_mod + rate_dif;
-        if next_ir_mod > 10_000_000_000 {
-            new_ir_mod = 10_000_000_000;
+        let ir_mod_max = 10 * SCALAR_9;
+        if next_ir_mod > ir_mod_max {
+            new_ir_mod = ir_mod_max;
         } else {
             new_ir_mod = next_ir_mod;
         }
@@ -95,8 +96,9 @@ pub fn calc_accrual(
             .fixed_mul_ceil(i128(config.reactivity), SCALAR_9)
             .unwrap_optimized();
         let next_ir_mod = ir_mod + rate_dif;
-        if next_ir_mod < 0_100_000_000 {
-            new_ir_mod = 0_100_000_000;
+        let ir_mod_min = SCALAR_9 / 10;
+        if next_ir_mod < ir_mod_min {
+            new_ir_mod = ir_mod_min;
         } else {
             new_ir_mod = next_ir_mod;
         }
@@ -105,7 +107,7 @@ pub fn calc_accrual(
     // calc accrual amount over blocks
     let time_weight = delta_time_scaled / SECONDS_PER_YEAR;
     (
-        1_000_000_000
+        SCALAR_9
             + time_weight
                 .fixed_mul_ceil(cur_ir * 100, SCALAR_9)
                 .unwrap_optimized(),

--- a/pool/src/pool/mod.rs
+++ b/pool/src/pool/mod.rs
@@ -1,5 +1,5 @@
 mod actions;
-pub use actions::Request;
+pub use actions::{Request, RequestType};
 
 mod bad_debt;
 pub use bad_debt::transfer_bad_debt_to_backstop;

--- a/pool/src/pool/submit.rs
+++ b/pool/src/pool/submit.rs
@@ -65,7 +65,7 @@ pub fn execute_submit(
 mod tests {
     use crate::{
         storage::{self, PoolConfig},
-        testutils,
+        testutils, RequestType,
     };
 
     use super::*;
@@ -138,12 +138,12 @@ mod tests {
             let requests = vec![
                 &e,
                 Request {
-                    request_type: 2,
+                    request_type: RequestType::SupplyCollateral as u32,
                     address: underlying_0,
                     amount: 15_0000000,
                 },
                 Request {
-                    request_type: 4,
+                    request_type: RequestType::Borrow as u32,
                     address: underlying_1,
                     amount: 1_5000000,
                 },
@@ -228,12 +228,12 @@ mod tests {
             let requests = vec![
                 &e,
                 Request {
-                    request_type: 2,
+                    request_type: RequestType::SupplyCollateral as u32,
                     address: underlying_0,
                     amount: 15_0000000,
                 },
                 Request {
-                    request_type: 4,
+                    request_type: RequestType::Borrow as u32,
                     address: underlying_1,
                     amount: 1_7500000,
                 },
@@ -293,7 +293,7 @@ mod tests {
             let requests = vec![
                 &e,
                 Request {
-                    request_type: 2,
+                    request_type: RequestType::SupplyCollateral as u32,
                     address: underlying_0,
                     amount: 15_0000000,
                 },
@@ -353,7 +353,7 @@ mod tests {
             let requests = vec![
                 &e,
                 Request {
-                    request_type: 2,
+                    request_type: RequestType::SupplyCollateral as u32,
                     address: underlying_0,
                     amount: 15_0000000,
                 },
@@ -413,7 +413,7 @@ mod tests {
             let requests = vec![
                 &e,
                 Request {
-                    request_type: 2,
+                    request_type: RequestType::SupplyCollateral as u32,
                     address: underlying_0,
                     amount: 15_0000000,
                 },

--- a/pool/src/pool/user.rs
+++ b/pool/src/pool/user.rs
@@ -217,7 +217,8 @@ impl User {
 mod tests {
     use super::*;
     use crate::{
-        storage, testutils, ReserveEmissionsConfig, ReserveEmissionsData, UserEmissionData,
+        constants::SCALAR_7, storage, testutils, ReserveEmissionsConfig, ReserveEmissionsData,
+        UserEmissionData,
     };
     use soroban_fixed_point_math::FixedPoint;
     use soroban_sdk::{
@@ -345,7 +346,7 @@ mod tests {
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
             let new_index = 1000
                 + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_d_supply_0, 1_0000000)
+                    .fixed_div_floor(starting_d_supply_0, SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);
@@ -353,7 +354,7 @@ mod tests {
                 storage::get_user_emissions(&e, &samwise, &res_0_d_token_index).unwrap();
             let new_accrual = 0
                 + (new_index - emis_user_data.index)
-                    .fixed_mul_floor(1000, 1_0000000)
+                    .fixed_mul_floor(1000, SCALAR_7)
                     .unwrap();
             assert_eq!(user_emis_data.accrued, new_accrual);
         });
@@ -412,7 +413,7 @@ mod tests {
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
             let new_index = 1000
                 + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_d_supply_0, 1_0000000)
+                    .fixed_div_floor(starting_d_supply_0, SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);
@@ -420,7 +421,7 @@ mod tests {
                 storage::get_user_emissions(&e, &samwise, &res_0_d_token_index).unwrap();
             let new_accrual = 0
                 + (new_index - emis_user_data.index)
-                    .fixed_mul_floor(1000, 1_0000000)
+                    .fixed_mul_floor(1000, SCALAR_7)
                     .unwrap();
             assert_eq!(user_emis_data.accrued, new_accrual);
         });
@@ -540,7 +541,7 @@ mod tests {
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
             let new_index = 1000
                 + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_b_token_supply, 1_0000000)
+                    .fixed_div_floor(starting_b_token_supply, SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);
@@ -548,7 +549,7 @@ mod tests {
                 storage::get_user_emissions(&e, &samwise, &res_0_d_token_index).unwrap();
             let new_accrual = 0
                 + (new_index - emis_user_data.index)
-                    .fixed_mul_floor(1000, 1_0000000)
+                    .fixed_mul_floor(1000, SCALAR_7)
                     .unwrap();
             assert_eq!(user_emis_data.accrued, new_accrual);
         });
@@ -608,7 +609,7 @@ mod tests {
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
             let new_index = 1000
                 + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_b_token_supply, 1_0000000)
+                    .fixed_div_floor(starting_b_token_supply, SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);
@@ -616,7 +617,7 @@ mod tests {
                 storage::get_user_emissions(&e, &samwise, &res_0_d_token_index).unwrap();
             let new_accrual = 0
                 + (new_index - emis_user_data.index)
-                    .fixed_mul_floor(1000, 1_0000000)
+                    .fixed_mul_floor(1000, SCALAR_7)
                     .unwrap();
             assert_eq!(user_emis_data.accrued, new_accrual);
         });
@@ -737,7 +738,7 @@ mod tests {
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
             let new_index = 1000
                 + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_b_token_supply, 1_0000000)
+                    .fixed_div_floor(starting_b_token_supply, SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);
@@ -745,7 +746,7 @@ mod tests {
                 storage::get_user_emissions(&e, &samwise, &res_0_d_token_index).unwrap();
             let new_accrual = 0
                 + (new_index - emis_user_data.index)
-                    .fixed_mul_floor(1000, 1_0000000)
+                    .fixed_mul_floor(1000, SCALAR_7)
                     .unwrap();
             assert_eq!(user_emis_data.accrued, new_accrual);
         });
@@ -805,7 +806,7 @@ mod tests {
             let new_emis_res_data = storage::get_res_emis_data(&e, &res_0_d_token_index).unwrap();
             let new_index = 1000
                 + (1000i128 * 0_1000000)
-                    .fixed_div_floor(starting_b_token_supply, 1_0000000)
+                    .fixed_div_floor(starting_b_token_supply, SCALAR_7)
                     .unwrap();
             assert_eq!(new_emis_res_data.last_time, 10001000);
             assert_eq!(new_emis_res_data.index, new_index);
@@ -813,7 +814,7 @@ mod tests {
                 storage::get_user_emissions(&e, &samwise, &res_0_d_token_index).unwrap();
             let new_accrual = 0
                 + (new_index - emis_user_data.index)
-                    .fixed_mul_floor(1000, 1_0000000)
+                    .fixed_mul_floor(1000, SCALAR_7)
                     .unwrap();
             assert_eq!(user_emis_data.accrued, new_accrual);
         });

--- a/test-suites/fuzz/lib.rs
+++ b/test-suites/fuzz/lib.rs
@@ -137,7 +137,7 @@ impl Supply {
             &vec![
                 &fixture.env,
                 Request {
-                    request_type: 2,
+                    request_type: RequestType::SupplyCollateral as u32,
                     address: token,
                     amount: self.amount,
                 },
@@ -164,7 +164,7 @@ impl Withdraw {
             &vec![
                 &fixture.env,
                 Request {
-                    request_type: 3,
+                    request_type: RequestType::WithdrawCollateral as u32,
                     address: token,
                     amount: self.amount,
                 },
@@ -191,7 +191,7 @@ impl Borrow {
             &vec![
                 &fixture.env,
                 Request {
-                    request_type: 4,
+                    request_type: RequestType::Borrow as u32,
                     address: token,
                     amount: self.amount,
                 },
@@ -218,7 +218,7 @@ impl Repay {
             &vec![
                 &fixture.env,
                 Request {
-                    request_type: 5,
+                    request_type: RequestType::Repay as u32,
                     address: token,
                     amount: self.amount,
                 },

--- a/test-suites/src/setup.rs
+++ b/test-suites/src/setup.rs
@@ -1,4 +1,4 @@
-use pool::{Request, ReserveEmissionMetadata};
+use pool::{Request, RequestType, ReserveEmissionMetadata};
 use soroban_sdk::{testutils::Address as _, vec as svec, Address, Symbol, Vec as SVec};
 
 use crate::{
@@ -109,12 +109,12 @@ pub fn create_fixture_with_data<'a>(wasm: bool) -> TestFixture<'a> {
     let requests: SVec<Request> = svec![
         &fixture.env,
         Request {
-            request_type: 2,
+            request_type: RequestType::SupplyCollateral as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: 10_000 * 10i128.pow(6),
         },
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: 8_000 * 10i128.pow(6),
         },
@@ -125,12 +125,12 @@ pub fn create_fixture_with_data<'a>(wasm: bool) -> TestFixture<'a> {
     let requests: SVec<Request> = svec![
         &fixture.env,
         Request {
-            request_type: 2,
+            request_type: RequestType::SupplyCollateral as u32,
             address: fixture.tokens[TokenIndex::WETH].address.clone(),
             amount: 10 * 10i128.pow(9),
         },
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: fixture.tokens[TokenIndex::WETH].address.clone(),
             amount: 5 * 10i128.pow(9),
         },
@@ -141,12 +141,12 @@ pub fn create_fixture_with_data<'a>(wasm: bool) -> TestFixture<'a> {
     let requests: SVec<Request> = svec![
         &fixture.env,
         Request {
-            request_type: 2,
+            request_type: RequestType::SupplyCollateral as u32,
             address: fixture.tokens[TokenIndex::XLM].address.clone(),
             amount: 100_000 * SCALAR_7,
         },
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: fixture.tokens[TokenIndex::XLM].address.clone(),
             amount: 65_000 * SCALAR_7,
         },

--- a/test-suites/tests/test_liquidation.rs
+++ b/test-suites/tests/test_liquidation.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 use cast::i128;
-use pool::{PoolDataKey, Positions, Request, ReserveConfig, ReserveData};
+use pool::{PoolDataKey, Positions, Request, RequestType, ReserveConfig, ReserveData};
 use soroban_fixed_point_math::FixedPoint;
 use soroban_sdk::{
     testutils::{Address as AddressTestTrait, Events},
@@ -22,32 +22,32 @@ fn test_liquidations() {
     let requests: Vec<Request> = vec![
         &fixture.env,
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: 1,
         },
         Request {
-            request_type: 5,
+            request_type: RequestType::Repay as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: 1,
         },
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: fixture.tokens[TokenIndex::XLM].address.clone(),
             amount: 1,
         },
         Request {
-            request_type: 5,
+            request_type: RequestType::Repay as u32,
             address: fixture.tokens[TokenIndex::XLM].address.clone(),
             amount: 1,
         },
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: fixture.tokens[TokenIndex::WETH].address.clone(),
             amount: 1,
         },
         Request {
-            request_type: 5,
+            request_type: RequestType::Repay as u32,
             address: fixture.tokens[TokenIndex::WETH].address.clone(),
             amount: 1,
         },
@@ -95,7 +95,7 @@ fn test_liquidations() {
     let frodo_requests: Vec<Request> = vec![
         &fixture.env,
         Request {
-            request_type: 2,
+            request_type: RequestType::SupplyCollateral as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: 30_000 * 10i128.pow(6),
         },
@@ -108,23 +108,23 @@ fn test_liquidations() {
     let sam_requests: Vec<Request> = vec![
         &fixture.env,
         Request {
-            request_type: 2,
+            request_type: RequestType::SupplyCollateral as u32,
             address: fixture.tokens[TokenIndex::XLM].address.clone(),
             amount: 160_000 * SCALAR_7,
         },
         Request {
-            request_type: 2,
+            request_type: RequestType::SupplyCollateral as u32,
             address: fixture.tokens[TokenIndex::WETH].address.clone(),
             amount: 17 * 10i128.pow(9),
         },
         // Sam's max borrow is 39_200 STABLE
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: 28_000 * 10i128.pow(6),
         }, // reduces Sam's max borrow to 14_526.31579 STABLE
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: fixture.tokens[TokenIndex::XLM].address.clone(),
             amount: 65_000 * SCALAR_7,
         },
@@ -252,27 +252,27 @@ fn test_liquidations() {
     let fill_requests = vec![
         &fixture.env,
         Request {
-            request_type: 6,
+            request_type: RequestType::FillUserLiquidationAuction as u32,
             address: samwise.clone(),
             amount: 25,
         },
         Request {
-            request_type: 6,
+            request_type: RequestType::FillUserLiquidationAuction as u32,
             address: samwise.clone(),
             amount: 100,
         },
         Request {
-            request_type: 8,
+            request_type: RequestType::FillInterestAuction as u32,
             address: fixture.backstop.address.clone(), //address shouldn't matter
             amount: 99,
         },
         Request {
-            request_type: 8,
+            request_type: RequestType::FillInterestAuction as u32,
             address: fixture.backstop.address.clone(), //address shouldn't matter
             amount: 100,
         },
         Request {
-            request_type: 5,
+            request_type: RequestType::Repay as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: usdc_bid_amount,
         },
@@ -463,19 +463,19 @@ fn test_liquidations() {
     let fill_requests = vec![
         &fixture.env,
         Request {
-            request_type: 6,
+            request_type: RequestType::FillUserLiquidationAuction as u32,
             address: samwise.clone(),
             amount: 100,
         },
         Request {
-            request_type: 5,
+            request_type: RequestType::Repay as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: usdc_bid_amount
                 .fixed_div_floor(2_0000000, SCALAR_7)
                 .unwrap(),
         },
         Request {
-            request_type: 5,
+            request_type: RequestType::Repay as u32,
             address: fixture.tokens[TokenIndex::XLM].address.clone(),
             amount: xlm_bid_amount.fixed_div_floor(2_0000000, SCALAR_7).unwrap(),
         },
@@ -595,7 +595,7 @@ fn test_liquidations() {
     let bad_debt_fill_request = vec![
         &fixture.env,
         Request {
-            request_type: 7,
+            request_type: RequestType::FillBadDebtAuction as u32,
             address: fixture.backstop.address.clone(),
             amount: 20,
         },
@@ -704,7 +704,7 @@ fn test_liquidations() {
     let bad_debt_fill_request = vec![
         &fixture.env,
         Request {
-            request_type: 7,
+            request_type: RequestType::FillBadDebtAuction as u32,
             address: fixture.backstop.address.clone(),
             amount: 100,
         },
@@ -784,13 +784,13 @@ fn test_liquidations() {
     let sam_requests: Vec<Request> = vec![
         &fixture.env,
         Request {
-            request_type: 2,
+            request_type: RequestType::SupplyCollateral as u32,
             address: fixture.tokens[TokenIndex::WETH].address.clone(),
             amount: 1 * 10i128.pow(9),
         },
         // Sam's max borrow is 39_200 STABLE
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: 100 * 10i128.pow(6),
         }, // reduces Sam's max borrow to 14_526.31579 STABLE
@@ -849,7 +849,7 @@ fn test_liquidations() {
     let bad_debt_fill_request = vec![
         &fixture.env,
         Request {
-            request_type: 6,
+            request_type: RequestType::FillUserLiquidationAuction as u32,
             address: samwise.clone(),
             amount: 100,
         },
@@ -895,7 +895,7 @@ fn test_liquidations() {
     let bump_usdc = vec![
         &fixture.env,
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: 1,
         },
@@ -928,7 +928,7 @@ fn test_liquidations() {
     let bad_debt_fill_request = vec![
         &fixture.env,
         Request {
-            request_type: 7,
+            request_type: RequestType::FillBadDebtAuction as u32,
             address: fixture.backstop.address.clone(),
             amount: 100,
         },
@@ -998,12 +998,12 @@ fn test_user_restore_position_and_delete_liquidation() {
     let setup_request: Vec<Request> = vec![
         &fixture.env,
         Request {
-            request_type: 2,
+            request_type: RequestType::SupplyCollateral as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: 1000 * 10i128.pow(6),
         },
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: fixture.tokens[TokenIndex::XLM].address.clone(),
             amount: 6075 * SCALAR_7,
         },
@@ -1030,7 +1030,7 @@ fn test_user_restore_position_and_delete_liquidation() {
     let delete_only_request: Vec<Request> = vec![
         &fixture.env,
         Request {
-            request_type: 9,
+            request_type: RequestType::DeleteLiquidationAuction as u32,
             address: Address::generate(&fixture.env),
             amount: i128::MAX,
         },
@@ -1045,12 +1045,12 @@ fn test_user_restore_position_and_delete_liquidation() {
     let short_supply_delete_request: Vec<Request> = vec![
         &fixture.env,
         Request {
-            request_type: 2,
+            request_type: RequestType::SupplyCollateral as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: 79 * 10i128.pow(6), // need $80 more collateral
         },
         Request {
-            request_type: 9,
+            request_type: RequestType::DeleteLiquidationAuction as u32,
             address: Address::generate(&fixture.env),
             amount: i128::MAX,
         },
@@ -1067,12 +1067,12 @@ fn test_user_restore_position_and_delete_liquidation() {
     let short_repay_delete_request: Vec<Request> = vec![
         &fixture.env,
         Request {
-            request_type: 9,
+            request_type: RequestType::DeleteLiquidationAuction as u32,
             address: Address::generate(&fixture.env),
             amount: i128::MAX,
         },
         Request {
-            request_type: 5,
+            request_type: RequestType::Repay as u32,
             address: fixture.tokens[TokenIndex::XLM].address.clone(),
             amount: 449 * SCALAR_7, // need to repay 450 XLM
         },
@@ -1090,17 +1090,17 @@ fn test_user_restore_position_and_delete_liquidation() {
     let delete_request: Vec<Request> = vec![
         &fixture.env,
         Request {
-            request_type: 2,
+            request_type: RequestType::SupplyCollateral as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: 41 * 10i128.pow(6),
         },
         Request {
-            request_type: 9,
+            request_type: RequestType::DeleteLiquidationAuction as u32,
             address: Address::generate(&fixture.env),
             amount: i128::MAX,
         },
         Request {
-            request_type: 5,
+            request_type: RequestType::Repay as u32,
             address: fixture.tokens[TokenIndex::XLM].address.clone(),
             amount: 226 * SCALAR_7,
         },

--- a/test-suites/tests/test_overflow_flag.rs
+++ b/test-suites/tests/test_overflow_flag.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-use pool::Request;
+use pool::{Request, RequestType};
 use soroban_sdk::{testutils::Address as AddressTestTrait, vec, Address, Vec};
 use test_suites::{
     create_fixture_with_data,
@@ -47,12 +47,12 @@ fn test_auction_underflow_panics() {
     let sam_requests: Vec<Request> = vec![
         &fixture.env,
         Request {
-            request_type: 2,
+            request_type: RequestType::SupplyCollateral as u32,
             address: fixture.tokens[TokenIndex::XLM].address.clone(),
             amount: 6_000 * SCALAR_7,
         },
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: 200 * 10i128.pow(6),
         },
@@ -84,12 +84,12 @@ fn test_auction_underflow_panics() {
     let fill_requests = vec![
         &fixture.env,
         Request {
-            request_type: 6,
+            request_type: RequestType::FillUserLiquidationAuction as u32,
             address: samwise.clone(),
             amount: 1,
         },
         Request {
-            request_type: 5,
+            request_type: RequestType::Repay as u32,
             address: fixture.tokens[TokenIndex::STABLE].address.clone(),
             amount: usdc_bid_amount,
         },

--- a/test-suites/tests/test_pool.rs
+++ b/test-suites/tests/test_pool.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use pool::{Request, ReserveEmissionMetadata};
+use pool::{Request, RequestType, ReserveEmissionMetadata};
 use soroban_fixed_point_math::FixedPoint;
 use soroban_sdk::{
     testutils::{Address as _, AuthorizedFunction, AuthorizedInvocation, Events},
@@ -45,7 +45,7 @@ fn test_pool_user() {
     let requests = vec![
         &fixture.env,
         Request {
-            request_type: 0,
+            request_type: RequestType::Supply as u32,
             address: weth.address.clone(),
             amount,
         },
@@ -131,7 +131,7 @@ fn test_pool_user() {
     let requests = vec![
         &fixture.env,
         Request {
-            request_type: 1,
+            request_type: RequestType::Withdraw as u32,
             address: weth.address.clone(),
             amount,
         },
@@ -201,7 +201,7 @@ fn test_pool_user() {
     let requests = vec![
         &fixture.env,
         Request {
-            request_type: 2,
+            request_type: RequestType::SupplyCollateral as u32,
             address: xlm.address.clone(),
             amount,
         },
@@ -284,7 +284,7 @@ fn test_pool_user() {
     let requests = vec![
         &fixture.env,
         Request {
-            request_type: 4,
+            request_type: RequestType::Borrow as u32,
             address: weth.address.clone(),
             amount,
         },
@@ -367,12 +367,12 @@ fn test_pool_user() {
     let requests = vec![
         &fixture.env,
         Request {
-            request_type: 3,
+            request_type: RequestType::WithdrawCollateral as u32,
             address: xlm.address.clone(),
             amount: amount_withdrawal,
         },
         Request {
-            request_type: 5,
+            request_type: RequestType::Repay as u32,
             address: weth.address.clone(),
             amount: amount_repay,
         },

--- a/test-suites/tests/test_wasm_happy_path.rs
+++ b/test-suites/tests/test_wasm_happy_path.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use pool::Request;
+use pool::{Request, RequestType};
 use soroban_fixed_point_math::FixedPoint;
 use soroban_sdk::{testutils::Address as _, vec, Address};
 use test_suites::{
@@ -51,7 +51,7 @@ fn test_wasm_happy_path() {
         &vec![
             &fixture.env,
             Request {
-                request_type: 2,
+                request_type: RequestType::SupplyCollateral as u32,
                 address: stable.address.clone(),
                 amount,
             },
@@ -83,7 +83,7 @@ fn test_wasm_happy_path() {
         &vec![
             &fixture.env,
             Request {
-                request_type: 2,
+                request_type: RequestType::SupplyCollateral as u32,
                 address: xlm.address.clone(),
                 amount,
             },
@@ -112,7 +112,7 @@ fn test_wasm_happy_path() {
         &vec![
             &fixture.env,
             Request {
-                request_type: 4,
+                request_type: RequestType::Borrow as u32,
                 address: stable.address.clone(),
                 amount,
             },
@@ -144,7 +144,7 @@ fn test_wasm_happy_path() {
         &vec![
             &fixture.env,
             Request {
-                request_type: 4,
+                request_type: RequestType::Borrow as u32,
                 address: xlm.address.clone(),
                 amount,
             },
@@ -247,7 +247,7 @@ fn test_wasm_happy_path() {
         &vec![
             &fixture.env,
             Request {
-                request_type: 5,
+                request_type: RequestType::Repay as u32,
                 address: stable.address.clone(),
                 amount,
             },
@@ -279,7 +279,7 @@ fn test_wasm_happy_path() {
         &vec![
             &fixture.env,
             Request {
-                request_type: 5,
+                request_type: RequestType::Repay as u32,
                 address: xlm.address.clone(),
                 amount,
             },
@@ -308,7 +308,7 @@ fn test_wasm_happy_path() {
         &vec![
             &fixture.env,
             Request {
-                request_type: 3,
+                request_type: RequestType::WithdrawCollateral as u32,
                 address: xlm.address.clone(),
                 amount,
             },
@@ -337,7 +337,7 @@ fn test_wasm_happy_path() {
         &vec![
             &fixture.env,
             Request {
-                request_type: 3,
+                request_type: RequestType::WithdrawCollateral as u32,
                 address: stable.address.clone(),
                 amount,
             },
@@ -473,7 +473,7 @@ fn test_wasm_happy_path() {
         &vec![
             &fixture.env,
             Request {
-                request_type: 5,
+                request_type: RequestType::Repay as u32,
                 address: stable.address.clone(),
                 amount: amount,
             },
@@ -505,7 +505,7 @@ fn test_wasm_happy_path() {
         &vec![
             &fixture.env,
             Request {
-                request_type: 5,
+                request_type: RequestType::Repay as u32,
                 address: xlm.address.clone(),
                 amount: amount,
             },
@@ -538,7 +538,7 @@ fn test_wasm_happy_path() {
         &vec![
             &fixture.env,
             Request {
-                request_type: 3,
+                request_type: RequestType::WithdrawCollateral as u32,
                 address: xlm.address.clone(),
                 amount: amount,
             },
@@ -566,7 +566,7 @@ fn test_wasm_happy_path() {
         &vec![
             &fixture.env,
             Request {
-                request_type: 3,
+                request_type: RequestType::WithdrawCollateral as u32,
                 address: stable.address.clone(),
                 amount: amount,
             },


### PR DESCRIPTION
Fixes: #167 

Opted to keep the interface using a `u32` for the request object. Forcing the contractType to be an enum increased the contract size a non-negligible amount, and made the interface harder to interact with for consumers in other languages.

Creating an issue for the JS-SDK to expose an enum as well to help alleviate this.