### PR TITLE
pool: fix: update reactivity constant bounds

### DIFF
--- a/backstop/src/contract.rs
+++ b/backstop/src/contract.rs
@@ -207,7 +207,7 @@ impl Backstop for BackstopContract {
         drop_list: Map<Address, i128>,
     ) {
         storage::extend_instance(&e);
-        if storage::has_backstop_token(&e) {
+        if storage::get_is_init(&e) {
             panic_with_error!(e, BackstopError::AlreadyInitialized);
         }
 
@@ -224,6 +224,8 @@ impl Backstop for BackstopContract {
         let last_distribution_time =
             EmitterClient::new(&e, &emitter).get_last_distro(&e.current_contract_address());
         storage::set_last_distribution_time(&e, &last_distribution_time);
+
+        storage::set_is_init(&e);
     }
 
     /********** Core **********/

--- a/backstop/src/storage.rs
+++ b/backstop/src/storage.rs
@@ -39,6 +39,7 @@ pub struct UserEmissionData {
 
 /********** Storage Key Types **********/
 
+const IS_INIT_KEY: &str = "IsInit";
 const EMITTER_KEY: &str = "Emitter";
 const BACKSTOP_TOKEN_KEY: &str = "BToken";
 const POOL_FACTORY_KEY: &str = "PoolFact";
@@ -97,7 +98,19 @@ fn get_persistent_default<K: IntoVal<Env, Val>, V: TryFromVal<Env, Val>>(
     }
 }
 
-/********** External Contracts **********/
+/********** Instance Storage **********/
+
+/// Check if the contract has been initialized
+pub fn get_is_init(e: &Env) -> bool {
+    e.storage().instance().has(&Symbol::new(e, IS_INIT_KEY))
+}
+
+/// Set the contract as initialized
+pub fn set_is_init(e: &Env) {
+    e.storage()
+        .instance()
+        .set::<Symbol, bool>(&Symbol::new(e, IS_INIT_KEY), &true);
+}
 
 /// Fetch the pool factory id
 pub fn get_emitter(e: &Env) -> Address {
@@ -177,13 +190,6 @@ pub fn get_backstop_token(e: &Env) -> Address {
         .instance()
         .get::<Symbol, Address>(&Symbol::new(e, BACKSTOP_TOKEN_KEY))
         .unwrap_optimized()
-}
-
-/// Checks if a backstop token is set for the backstop
-pub fn has_backstop_token(e: &Env) -> bool {
-    e.storage()
-        .instance()
-        .has(&Symbol::new(e, BACKSTOP_TOKEN_KEY))
 }
 
 /// Set the backstop token id

--- a/emitter/src/contract.rs
+++ b/emitter/src/contract.rs
@@ -76,7 +76,7 @@ pub trait Emitter {
 impl Emitter for EmitterContract {
     fn initialize(e: Env, blnd_token: Address, backstop: Address, backstop_token: Address) {
         storage::extend_instance(&e);
-        if storage::has_blnd_token(&e) {
+        if storage::get_is_init(&e) {
             panic_with_error!(&e, EmitterError::AlreadyInitialized)
         }
 
@@ -84,6 +84,8 @@ impl Emitter for EmitterContract {
         storage::set_backstop(&e, &backstop);
         storage::set_backstop_token(&e, &backstop_token);
         storage::set_last_distro_time(&e, &backstop, e.ledger().timestamp());
+
+        storage::set_is_init(&e);
     }
 
     fn distribute(e: Env) -> i128 {

--- a/emitter/src/storage.rs
+++ b/emitter/src/storage.rs
@@ -7,6 +7,7 @@ pub(crate) const LEDGER_BUMP_SHARED: u32 = 241920; // ~ 14 days
 
 /********** Storage **********/
 
+const IS_INIT_KEY: &str = "IsInit";
 const BACKSTOP_KEY: &str = "Backstop";
 const BACKSTOP_TOKEN_KEY: &str = "BToken";
 const BLND_TOKEN_KEY: &str = "BLNDTkn";
@@ -28,6 +29,20 @@ pub fn extend_instance(e: &Env) {
     e.storage()
         .instance()
         .extend_ttl(LEDGER_THRESHOLD_SHARED, LEDGER_BUMP_SHARED);
+}
+
+/********** Init **********/
+
+/// Check if the contract has been initialized
+pub fn get_is_init(e: &Env) -> bool {
+    e.storage().instance().has(&Symbol::new(e, IS_INIT_KEY))
+}
+
+/// Set the contract as initialized
+pub fn set_is_init(e: &Env) {
+    e.storage()
+        .instance()
+        .set::<Symbol, bool>(&Symbol::new(e, IS_INIT_KEY), &true);
 }
 
 /********** Backstop **********/
@@ -126,13 +141,6 @@ pub fn set_blnd_token(e: &Env, blnd_token: &Address) {
     e.storage()
         .instance()
         .set::<Symbol, Address>(&Symbol::new(e, BLND_TOKEN_KEY), blnd_token);
-}
-
-/// Check if the BLND token has been set
-///
-/// Returns true if a BLND token has been set
-pub fn has_blnd_token(e: &Env) -> bool {
-    e.storage().instance().has(&Symbol::new(e, BLND_TOKEN_KEY))
 }
 
 /********** Blend Distributions **********/

--- a/pool-factory/src/pool_factory.rs
+++ b/pool-factory/src/pool_factory.rs
@@ -51,10 +51,13 @@ pub trait PoolFactory {
 impl PoolFactory for PoolFactoryContract {
     fn initialize(e: Env, pool_init_meta: PoolInitMeta) {
         storage::extend_instance(&e);
-        if storage::has_pool_init_meta(&e) {
+        if storage::get_is_init(&e) {
             panic_with_error!(&e, PoolFactoryError::AlreadyInitialized);
         }
+
         storage::set_pool_init_meta(&e, &pool_init_meta);
+
+        storage::set_is_init(&e);
     }
 
     fn deploy(

--- a/pool-factory/src/storage.rs
+++ b/pool-factory/src/storage.rs
@@ -4,6 +4,8 @@ use soroban_sdk::{contracttype, unwrap::UnwrapOptimized, Address, BytesN, Env, S
 pub(crate) const LEDGER_THRESHOLD: u32 = 518400; // TODO: Check on phase 1 max ledger entry bump
 pub(crate) const LEDGER_BUMP: u32 = 535670; // TODO: Check on phase 1 max ledger entry bump
 
+const IS_INIT_KEY: &str = "IsInit";
+
 #[derive(Clone)]
 #[contracttype]
 pub enum PoolFactoryDataKey {
@@ -26,6 +28,18 @@ pub fn extend_instance(e: &Env) {
         .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
 }
 
+/// Check if the contract has been initialized
+pub fn get_is_init(e: &Env) -> bool {
+    e.storage().instance().has(&Symbol::new(e, IS_INIT_KEY))
+}
+
+/// Set the contract as initialized
+pub fn set_is_init(e: &Env) {
+    e.storage()
+        .instance()
+        .set::<Symbol, bool>(&Symbol::new(e, IS_INIT_KEY), &true);
+}
+
 /// Fetch the pool initialization metadata
 pub fn get_pool_init_meta(e: &Env) -> PoolInitMeta {
     e.storage()
@@ -42,11 +56,6 @@ pub fn set_pool_init_meta(e: &Env, pool_init_meta: &PoolInitMeta) {
     e.storage()
         .instance()
         .set::<Symbol, PoolInitMeta>(&Symbol::new(e, "PoolMeta"), pool_init_meta)
-}
-
-/// Check if the factory has a WASM hash set
-pub fn has_pool_init_meta(e: &Env) -> bool {
-    e.storage().instance().has(&Symbol::new(e, "PoolMeta"))
 }
 
 /// Check if a given contract_id was deployed by the factory

--- a/pool/src/pool/config.rs
+++ b/pool/src/pool/config.rs
@@ -161,7 +161,7 @@ fn require_valid_reserve_metadata(e: &Env, metadata: &ReserveConfig) {
         || metadata.util > 0_9500000
         || (metadata.max_util > SCALAR_7_U32 || metadata.max_util <= metadata.util)
         || (metadata.r_one > metadata.r_two || metadata.r_two > metadata.r_three)
-        || (metadata.reactivity > 0_0005000)
+        || (metadata.reactivity > 0_0001000)
     {
         panic_with_error!(e, PoolError::InvalidReserveMetadata);
     }
@@ -887,7 +887,7 @@ mod tests {
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
-            reactivity: 5001,
+            reactivity: 0_0001001,
         };
         require_valid_reserve_metadata(&e, &metadata);
     }

--- a/pool/src/pool/interest.rs
+++ b/pool/src/pool/interest.rs
@@ -78,7 +78,7 @@ pub fn calc_accrual(
             .fixed_mul_floor(util_dif_scaled, SCALAR_9)
             .unwrap_optimized();
         let rate_dif = util_error
-            .fixed_mul_floor(i128(config.reactivity), SCALAR_9)
+            .fixed_mul_floor(i128(config.reactivity), SCALAR_7)
             .unwrap_optimized();
         let next_ir_mod = ir_mod + rate_dif;
         let ir_mod_max = 10 * SCALAR_9;
@@ -93,7 +93,7 @@ pub fn calc_accrual(
             .fixed_mul_ceil(util_dif_scaled, SCALAR_9)
             .unwrap_optimized();
         let rate_dif = util_error
-            .fixed_mul_ceil(i128(config.reactivity), SCALAR_9)
+            .fixed_mul_ceil(i128(config.reactivity), SCALAR_7)
             .unwrap_optimized();
         let next_ir_mod = ir_mod + rate_dif;
         let ir_mod_min = SCALAR_9 / 10;
@@ -133,7 +133,7 @@ mod tests {
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
-            reactivity: 0_000_002_000,
+            reactivity: 0_0000020,
             index: 0,
         };
         let ir_mod: i128 = 1_000_000_000;
@@ -168,7 +168,7 @@ mod tests {
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
-            reactivity: 0_000_002_000,
+            reactivity: 0_0000020,
             index: 0,
         };
         let ir_mod: i128 = 1_000_000_000;
@@ -203,7 +203,7 @@ mod tests {
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
-            reactivity: 0_000_002_000,
+            reactivity: 0_0000020,
             index: 0,
         };
         let ir_mod: i128 = 1_000_000_000;
@@ -238,7 +238,7 @@ mod tests {
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
-            reactivity: 0_000_002_000,
+            reactivity: 0_0000020,
             index: 0,
         };
         let ir_mod: i128 = 9_997_000_000;
@@ -272,7 +272,7 @@ mod tests {
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
-            reactivity: 0_000_002_000,
+            reactivity: 0_0000020,
             index: 0,
         };
         let ir_mod: i128 = 0_150_000_000;
@@ -306,7 +306,7 @@ mod tests {
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
-            reactivity: 0_000_002_000,
+            reactivity: 0_0000020,
             index: 0,
         };
         let ir_mod: i128 = 0_100_000_000;

--- a/pool/src/pool/reserve.rs
+++ b/pool/src/pool/reserve.rs
@@ -20,10 +20,10 @@ pub struct Reserve {
     pub c_factor: u32,         // the collateral factor for the reserve
     pub max_util: u32,         // the maximum utilization rate for the reserve
     pub last_time: u64,        // the last block the data was updated
-    pub scalar: i128,          // scalar used for balances
+    pub scalar: i128,          // scalar used for positions, b/d token supply, and credit
     pub d_rate: i128,          // the conversion rate from dToken to underlying (9 decimals)
     pub b_rate: i128,          // the conversion rate from bToken to underlying (9 decimals)
-    pub ir_mod: i128,          // the interest rate curve modifier
+    pub ir_mod: i128,          // the interest rate curve modifier (9 decimals)
     pub b_supply: i128,        // the total supply of b tokens
     pub d_supply: i128,        // the total supply of d tokens
     pub backstop_credit: i128, // the total amount of underlying tokens owed to the backstop

--- a/pool/src/storage.rs
+++ b/pool/src/storage.rs
@@ -44,8 +44,9 @@ pub struct ReserveConfig {
     pub r_one: u32,      // the R1 value in the interest rate formula scaled expressed in 7 decimals
     pub r_two: u32,      // the R2 value in the interest rate formula scaled expressed in 7 decimals
     pub r_three: u32,    // the R3 value in the interest rate formula scaled expressed in 7 decimals
-    pub reactivity: u32, // the reactivity constant for the reserve scaled expressed in 9 decimals
+    pub reactivity: u32, // the reactivity constant for the reserve scaled expressed in 7 decimals
 }
+
 #[derive(Clone)]
 #[contracttype]
 pub struct QueuedReserveInit {

--- a/pool/src/storage.rs
+++ b/pool/src/storage.rs
@@ -95,6 +95,7 @@ pub struct UserEmissionData {
 
 /********** Storage Key Types **********/
 
+const IS_INIT_KEY: &str = "IsInit";
 const ADMIN_KEY: &str = "Admin";
 const NAME_KEY: &str = "Name";
 const BACKSTOP_KEY: &str = "Backstop";
@@ -169,6 +170,20 @@ fn get_persistent_default<K: IntoVal<Env, Val>, V: TryFromVal<Env, Val>>(
     }
 }
 
+/********** Init **********/
+
+/// Check if the contract has been initialized
+pub fn get_is_init(e: &Env) -> bool {
+    e.storage().instance().has(&Symbol::new(e, IS_INIT_KEY))
+}
+
+/// Set the contract as initialized
+pub fn set_is_init(e: &Env) {
+    e.storage()
+        .instance()
+        .set::<Symbol, bool>(&Symbol::new(e, IS_INIT_KEY), &true);
+}
+
 /********** User **********/
 
 /// Fetch the user's positions or return an empty Positions struct
@@ -222,11 +237,6 @@ pub fn set_admin(e: &Env, new_admin: &Address) {
     e.storage()
         .instance()
         .set::<Symbol, Address>(&Symbol::new(e, ADMIN_KEY), new_admin);
-}
-
-/// Checks if an admin is set
-pub fn has_admin(e: &Env) -> bool {
-    e.storage().instance().has(&Symbol::new(e, ADMIN_KEY))
 }
 
 /********** Metadata **********/

--- a/pool/src/testutils.rs
+++ b/pool/src/testutils.rs
@@ -210,7 +210,7 @@ pub(crate) fn default_reserve_meta() -> (ReserveConfig, ReserveData) {
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
-            reactivity: 0_000_002_000, // 10e-5
+            reactivity: 0_0000020, // 2e-6
             index: 0,
         },
         ReserveData {

--- a/test-suites/src/pool.rs
+++ b/test-suites/src/pool.rs
@@ -15,7 +15,7 @@ pub fn default_reserve_metadata() -> ReserveConfig {
         r_one: 0_0500000,
         r_two: 0_5000000,
         r_three: 1_5000000,
-        reactivity: 0_000_002_000, // 10e-5
+        reactivity: 0_0000020, // 2e-6
         index: 0,
     }
 }


### PR DESCRIPTION
Fixes the contract portion of #166 

Also makes the reactivity modifier 7 decimals to keep in line with other reserve config options.