### PR TITLE
Backstop: lowered withdrawal queue - Emitter: Removed drop delay

### DIFF
--- a/backstop/src/backstop/user.rs
+++ b/backstop/src/backstop/user.rs
@@ -55,10 +55,10 @@ impl UserBalance {
 
         // user has enough tokens to withdrawal, add Q4W
         // TODO: Consider capping how many active Q4Ws a user can have
-        let thirty_days_in_sec = 30 * 24 * 60 * 60;
+        let twentyone_days_in_sec = 21 * 24 * 60 * 60;
         let new_q4w = Q4W {
             amount: to_q,
-            exp: e.ledger().timestamp() + thirty_days_in_sec,
+            exp: e.ledger().timestamp() + twentyone_days_in_sec,
         };
         self.q4w.push_back(new_q4w.clone());
     }
@@ -168,7 +168,7 @@ mod tests {
                 &e,
                 Q4W {
                     amount: to_queue,
-                    exp: 10000 + 30 * 24 * 60 * 60,
+                    exp: 10000 + 21 * 24 * 60 * 60,
                 },
             ],
         );
@@ -205,7 +205,7 @@ mod tests {
         user.queue_shares_for_withdrawal(&e, to_queue);
         cur_q4w.push_back(Q4W {
             amount: to_queue,
-            exp: 11000000 + 30 * 24 * 60 * 60,
+            exp: 11000000 + 21 * 24 * 60 * 60,
         });
         assert_eq_vec_q4w(&user.q4w, &cur_q4w);
     }

--- a/backstop/src/backstop/withdrawal.rs
+++ b/backstop/src/backstop/withdrawal.rs
@@ -124,7 +124,7 @@ mod tests {
                 &e,
                 Q4W {
                     amount: 42_0000000,
-                    exp: 10000 + 30 * 24 * 60 * 60,
+                    exp: 10000 + 21 * 24 * 60 * 60,
                 },
             ];
             assert_eq_vec_q4w(&new_user_balance.q4w, &expected_q4w);
@@ -235,7 +235,7 @@ mod tests {
                 &e,
                 Q4W {
                     amount: 35_0000000,
-                    exp: 10000 + 30 * 24 * 60 * 60,
+                    exp: 10000 + 21 * 24 * 60 * 60,
                 },
             ];
             assert_eq_vec_q4w(&new_user_balance.q4w, &expected_q4w);
@@ -335,7 +335,7 @@ mod tests {
         e.ledger().set(LedgerInfo {
             protocol_version: 20,
             sequence_number: 200,
-            timestamp: 10000 + 30 * 24 * 60 * 60 + 1,
+            timestamp: 10000 + 21 * 24 * 60 * 60 + 1,
             network_id: Default::default(),
             base_reserve: 10,
             min_temp_entry_ttl: 10,
@@ -401,7 +401,7 @@ mod tests {
         e.ledger().set(LedgerInfo {
             protocol_version: 20,
             sequence_number: 200,
-            timestamp: 10000 + 30 * 24 * 60 * 60 + 1,
+            timestamp: 10000 + 21 * 24 * 60 * 60 + 1,
             network_id: Default::default(),
             base_reserve: 10,
             min_temp_entry_ttl: 10,

--- a/emitter/src/backstop_manager.rs
+++ b/emitter/src/backstop_manager.rs
@@ -80,7 +80,6 @@ pub fn execute_swap_backstop(e: &Env) -> Swap {
     emitter::execute_distribute(e, &backstop);
 
     // swap backstop and token
-    storage::set_last_fork(e, e.ledger().sequence());
     storage::del_queued_swap(e);
     storage::set_backstop(e, &swap.new_backstop);
     storage::set_backstop_token(e, &swap.new_backstop_token);
@@ -135,14 +134,12 @@ mod tests {
             storage::set_backstop(&e, &backstop);
             storage::set_backstop_token(&e, &backstop_token);
             storage::set_drop_status(&e, &backstop);
-            storage::set_last_fork(&e, 123);
 
             execute_queue_swap_backstop(&e, &new_backstop, &new_backstop_token);
 
             // verify no swap occurred
             assert_eq!(storage::get_backstop(&e), backstop);
             assert_eq!(storage::get_backstop_token(&e), backstop_token);
-            assert_eq!(storage::get_last_fork(&e), 123);
 
             // verify swap is queued
             let swap = storage::get_queued_swap(&e);
@@ -188,7 +185,6 @@ mod tests {
             storage::set_backstop(&e, &backstop);
             storage::set_backstop_token(&e, &backstop_token);
             storage::set_drop_status(&e, &backstop);
-            storage::set_last_fork(&e, 123);
 
             execute_queue_swap_backstop(&e, &new_backstop, &new_backstop_token);
             assert!(false); // should panic
@@ -235,7 +231,6 @@ mod tests {
             storage::set_backstop(&e, &backstop);
             storage::set_backstop_token(&e, &backstop_token);
             storage::set_drop_status(&e, &backstop);
-            storage::set_last_fork(&e, 123);
             storage::set_queued_swap(&e, &swap);
 
             execute_queue_swap_backstop(&e, &new_backstop, &new_backstop_token);
@@ -284,7 +279,6 @@ mod tests {
             storage::set_backstop(&e, &backstop);
             storage::set_backstop_token(&e, &backstop_token);
             storage::set_drop_status(&e, &backstop);
-            storage::set_last_fork(&e, 123);
             storage::set_queued_swap(&e, &swap);
 
             execute_cancel_swap_backstop(&e);
@@ -292,7 +286,6 @@ mod tests {
             // verify no swap occurred
             assert_eq!(storage::get_backstop(&e), backstop);
             assert_eq!(storage::get_backstop_token(&e), backstop_token);
-            assert_eq!(storage::get_last_fork(&e), 123);
 
             // verify swap is removed
             let swap = storage::get_queued_swap(&e);
@@ -340,7 +333,6 @@ mod tests {
             storage::set_backstop(&e, &backstop);
             storage::set_backstop_token(&e, &backstop_token);
             storage::set_drop_status(&e, &backstop);
-            storage::set_last_fork(&e, 123);
             storage::set_queued_swap(&e, &swap);
 
             execute_cancel_swap_backstop(&e);
@@ -381,7 +373,6 @@ mod tests {
             storage::set_backstop(&e, &backstop);
             storage::set_backstop_token(&e, &backstop_token);
             storage::set_drop_status(&e, &backstop);
-            storage::set_last_fork(&e, 123);
 
             execute_cancel_swap_backstop(&e);
             assert!(false);
@@ -434,7 +425,6 @@ mod tests {
             storage::set_backstop_token(&e, &backstop_token);
             storage::set_blnd_token(&e, &blnd_token);
             storage::set_drop_status(&e, &backstop);
-            storage::set_last_fork(&e, 123);
             storage::set_queued_swap(&e, &swap);
 
             execute_swap_backstop(&e);
@@ -442,7 +432,6 @@ mod tests {
             // verify swap occurred
             assert_eq!(storage::get_backstop(&e), new_backstop);
             assert_eq!(storage::get_backstop_token(&e), new_backstop_token);
-            assert_eq!(storage::get_last_fork(&e), 500);
 
             // verify swap is removed
             let swap = storage::get_queued_swap(&e);
@@ -499,7 +488,6 @@ mod tests {
             storage::set_backstop_token(&e, &backstop_token);
             storage::set_blnd_token(&e, &blnd_token);
             storage::set_drop_status(&e, &backstop);
-            storage::set_last_fork(&e, 123);
             storage::set_queued_swap(&e, &swap);
 
             execute_swap_backstop(&e);
@@ -543,7 +531,6 @@ mod tests {
             storage::set_backstop_token(&e, &backstop_token);
             storage::set_blnd_token(&e, &blnd_token);
             storage::set_drop_status(&e, &backstop);
-            storage::set_last_fork(&e, 123);
 
             execute_swap_backstop(&e);
             assert!(false);
@@ -593,7 +580,6 @@ mod tests {
             storage::set_backstop_token(&e, &backstop_token);
             storage::set_blnd_token(&e, &blnd_token);
             storage::set_drop_status(&e, &backstop);
-            storage::set_last_fork(&e, 123);
             storage::set_queued_swap(&e, &swap);
 
             execute_swap_backstop(&e);

--- a/emitter/src/storage.rs
+++ b/emitter/src/storage.rs
@@ -11,7 +11,6 @@ const IS_INIT_KEY: &str = "IsInit";
 const BACKSTOP_KEY: &str = "Backstop";
 const BACKSTOP_TOKEN_KEY: &str = "BToken";
 const BLND_TOKEN_KEY: &str = "BLNDTkn";
-const LAST_FORK_KEY: &str = "LastFork";
 const SWAP_KEY: &str = "Swap";
 
 // Emitter Data Keys
@@ -192,24 +191,4 @@ pub fn set_drop_status(e: &Env, backstop: &Address) {
     e.storage()
         .instance()
         .set::<EmitterDataKey, bool>(&EmitterDataKey::Dropped(backstop.clone()), &true);
-}
-
-/// Get the last block an emission fork was executed
-///
-/// Returns true if the emitter has dropped
-pub fn get_last_fork(e: &Env) -> u32 {
-    e.storage()
-        .instance()
-        .get(&Symbol::new(e, LAST_FORK_KEY))
-        .unwrap_optimized()
-}
-
-/// Set whether the emitter has performed the drop distribution or not for the current backstop
-///
-/// ### Arguments
-/// * `new_status` - new drop status
-pub fn set_last_fork(e: &Env, block: u32) {
-    e.storage()
-        .instance()
-        .set::<Symbol, u32>(&Symbol::new(e, LAST_FORK_KEY), &block);
 }

--- a/test-suites/tests/test_backstop.rs
+++ b/test-suites/tests/test_backstop.rs
@@ -228,7 +228,7 @@ fn test_backstop() {
     assert_eq!(result.amount, amount);
     assert_eq!(
         result.exp,
-        fixture.env.ledger().timestamp() + 30 * 24 * 60 * 60
+        fixture.env.ledger().timestamp() + 21 * 24 * 60 * 60
     );
     assert_eq!(bstop_token.balance(&sam), sam_bstop_token_balance);
     assert_eq!(

--- a/test-suites/tests/test_wasm_happy_path.rs
+++ b/test-suites/tests/test_wasm_happy_path.rs
@@ -593,7 +593,7 @@ fn test_wasm_happy_path() {
     assert_eq!(result.amount, amount);
     assert_eq!(
         result.exp,
-        fixture.env.ledger().timestamp() + 60 * 60 * 24 * 30
+        fixture.env.ledger().timestamp() + 60 * 60 * 24 * 21
     );
     assert_eq!(fixture.lp.balance(&frodo), frodo_bstop_token_balance);
     assert_eq!(


### PR DESCRIPTION
In accordance with https://github.com/blend-capital/blend-contracts/issues/152

Lowered backstop withdrawal queue to 21 days

Removed drop delay because the backstop swap queue system means it's not necessary 