### PR TITLE
Update liquidation scalar usage

### DIFF
--- a/pool/src/auctions/user_liquidation_auction.rs
+++ b/pool/src/auctions/user_liquidation_auction.rs
@@ -294,7 +294,6 @@ mod tests {
             storage::set_user_positions(&e, &samwise, &positions);
             storage::set_pool_config(&e, &pool_config);
 
-            e.budget().reset_unlimited();
             let result = create_user_liq_auction_data(&e, &samwise, liq_pct);
             assert_eq!(result.block, 51);
             assert_eq!(result.bid.get_unchecked(underlying_2), 1_2375000);
@@ -387,7 +386,6 @@ mod tests {
             storage::set_user_positions(&e, &samwise, &positions);
             storage::set_pool_config(&e, &pool_config);
 
-            e.budget().reset_unlimited();
             let result = create_user_liq_auction_data(&e, &samwise, liq_pct);
 
             assert_eq!(result.block, 51);
@@ -480,7 +478,6 @@ mod tests {
         e.as_contract(&pool_address, || {
             storage::set_user_positions(&e, &samwise, &positions);
             storage::set_pool_config(&e, &pool_config);
-            e.budget().reset_unlimited();
             let result = create_user_liq_auction_data(&e, &samwise, liq_pct);
             assert_eq!(result.block, 51);
             assert_eq!(result.bid.get_unchecked(underlying_1), 10_0000000);
@@ -558,7 +555,6 @@ mod tests {
             &reserve_config_2,
             &reserve_data_2,
         );
-        e.budget().reset_unlimited();
 
         oracle_client.set_data(
             &bombadil,
@@ -594,7 +590,6 @@ mod tests {
             storage::set_user_positions(&e, &samwise, &positions);
             storage::set_pool_config(&e, &pool_config);
 
-            e.budget().reset_unlimited();
             create_user_liq_auction_data(&e, &samwise, liq_pct);
         });
     }
@@ -666,7 +661,6 @@ mod tests {
             &reserve_config_2,
             &reserve_data_2,
         );
-        e.budget().reset_unlimited();
 
         oracle_client.set_data(
             &bombadil,
@@ -702,7 +696,6 @@ mod tests {
             storage::set_user_positions(&e, &samwise, &positions);
             storage::set_pool_config(&e, &pool_config);
 
-            e.budget().reset_unlimited();
             create_user_liq_auction_data(&e, &samwise, liq_pct);
         });
     }
@@ -775,7 +768,6 @@ mod tests {
             &reserve_config_2,
             &reserve_data_2,
         );
-        e.budget().reset_unlimited();
 
         oracle_client.set_data(
             &bombadil,
@@ -811,7 +803,6 @@ mod tests {
             storage::set_user_positions(&e, &samwise, &positions);
             storage::set_pool_config(&e, &pool_config);
 
-            e.budget().reset_unlimited();
             create_user_liq_auction_data(&e, &samwise, liq_pct);
         });
     }
@@ -884,7 +875,6 @@ mod tests {
             &reserve_config_2,
             &reserve_data_2,
         );
-        e.budget().reset_unlimited();
 
         oracle_client.set_data(
             &bombadil,
@@ -941,7 +931,6 @@ mod tests {
                 min_persistent_entry_ttl: 17280,
                 max_entry_ttl: 9999999,
             });
-            e.budget().reset_unlimited();
             let mut pool = Pool::load(&e);
             let mut frodo_state = User::load(&e, &frodo);
             fill_user_liq_auction(&e, &mut pool, &mut auction_data, &samwise, &mut frodo_state);
@@ -1060,7 +1049,6 @@ mod tests {
             &reserve_config_2,
             &reserve_data_2,
         );
-        e.budget().reset_unlimited();
 
         oracle_client.set_data(
             &bombadil,
@@ -1117,7 +1105,6 @@ mod tests {
                 min_persistent_entry_ttl: 17280,
                 max_entry_ttl: 9999999,
             });
-            e.budget().reset_unlimited();
             let mut pool = Pool::load(&e);
             let mut frodo_state = User::load(&e, &frodo);
             fill_user_liq_auction(&e, &mut pool, &mut auction_data, &samwise, &mut frodo_state);

--- a/pool/src/auctions/user_liquidation_auction.rs
+++ b/pool/src/auctions/user_liquidation_auction.rs
@@ -108,12 +108,12 @@ pub fn create_user_liq_auction_data(
         let new_data = PositionData::calculate_from_positions(e, &mut pool, &user_state.positions);
 
         // Post-liq health factor must be under 1.15
-        if !new_data.require_hf_under(1_1500000) {
+        if new_data.is_hf_over(1_1500000) {
             panic_with_error!(e, PoolError::InvalidLiqTooLarge)
         };
 
         // Post-liq heath factor must be over 1.03
-        if !new_data.require_hf_over(1_0300000) {
+        if new_data.is_hf_under(1_0300000) {
             panic_with_error!(e, PoolError::InvalidLiqTooSmall)
         };
     }

--- a/pool/src/auctions/user_liquidation_auction.rs
+++ b/pool/src/auctions/user_liquidation_auction.rs
@@ -108,10 +108,14 @@ pub fn create_user_liq_auction_data(
         let new_data = PositionData::calculate_from_positions(e, &mut pool, &user_state.positions);
 
         // Post-liq health factor must be under 1.15
-        new_data.require_hf_under(e, 1_1500000, PoolError::InvalidLiqTooLarge);
+        if !new_data.require_hf_under(1_1500000) {
+            panic_with_error!(e, PoolError::InvalidLiqTooLarge)
+        };
 
         // Post-liq heath factor must be over 1.03
-        new_data.require_hf_over(e, 1_0300000, PoolError::InvalidLiqTooSmall);
+        if !new_data.require_hf_over(1_0300000) {
+            panic_with_error!(e, PoolError::InvalidLiqTooSmall)
+        };
     }
     liquidation_quote
 }

--- a/pool/src/auctions/user_liquidation_auction.rs
+++ b/pool/src/auctions/user_liquidation_auction.rs
@@ -30,7 +30,6 @@ pub fn create_user_liq_auction_data(
         block: e.ledger().sequence() + 1,
     };
     let mut pool = Pool::load(e);
-    let oracle_scalar = 10i128.pow(pool.load_price_decimals(e));
 
     let mut user_state = User::load(e, user);
     let reserve_list = storage::get_res_list(e);
@@ -44,12 +43,12 @@ pub fn create_user_liq_auction_data(
     // ensure liquidation size is fair and the collateral is large enough to allow for the auction to price the liquidation
     let avg_cf = position_data
         .collateral_base
-        .fixed_div_floor(position_data.collateral_raw, oracle_scalar)
+        .fixed_div_floor(position_data.collateral_raw, position_data.scalar)
         .unwrap_optimized();
     // avg_lf is the inverse of the average liability factor
     let avg_lf = position_data
         .liability_base
-        .fixed_div_floor(position_data.liability_raw, oracle_scalar)
+        .fixed_div_floor(position_data.liability_raw, position_data.scalar)
         .unwrap_optimized();
     let est_incentive = (SCALAR_7 - avg_cf.fixed_div_ceil(avg_lf, SCALAR_7).unwrap_optimized())
         .fixed_div_ceil(2 * SCALAR_7, SCALAR_7)
@@ -58,12 +57,12 @@ pub fn create_user_liq_auction_data(
 
     let est_withdrawn_collateral = position_data
         .liability_raw
-        .fixed_mul_floor(percent_liquidated_i128, oracle_scalar)
+        .fixed_mul_floor(percent_liquidated_i128, SCALAR_7)
         .unwrap_optimized()
         .fixed_mul_floor(est_incentive, SCALAR_7)
         .unwrap_optimized();
     let mut est_withdrawn_collateral_pct = est_withdrawn_collateral
-        .fixed_div_ceil(position_data.collateral_raw, oracle_scalar)
+        .fixed_div_ceil(position_data.collateral_raw, SCALAR_7)
         .unwrap_optimized();
     if est_withdrawn_collateral_pct > SCALAR_7 {
         est_withdrawn_collateral_pct = SCALAR_7;
@@ -105,13 +104,21 @@ pub fn create_user_liq_auction_data(
         );
         let new_hf = PositionData::calculate_from_positions(e, &mut pool, &user_state.positions)
             .as_health_factor();
-
+        liquidation_quote.bid.set(user.clone(), new_hf);
         //check if liq is too large
-        if new_hf > 1_1500000 {
+        let max_hf = position_data
+            .scalar
+            .fixed_mul_floor(1_1500000, SCALAR_7)
+            .unwrap_optimized();
+        let min_hf = position_data
+            .scalar
+            .fixed_mul_floor(1_0300000, SCALAR_7)
+            .unwrap_optimized();
+        if new_hf > max_hf {
             panic_with_error!(e, PoolError::InvalidLiqTooLarge);
         }
         // check if liq is too small
-        if new_hf < 1_0300000 {
+        if new_hf < min_hf {
             panic_with_error!(e, PoolError::InvalidLiqTooSmall);
         }
     }
@@ -133,6 +140,8 @@ pub fn fill_user_liq_auction(
 
 #[cfg(test)]
 mod tests {
+
+    use std::println;
 
     use crate::{
         auctions::auction::AuctionType,
@@ -304,6 +313,218 @@ mod tests {
             assert_eq!(result.lot.get_unchecked(underlying_0), 30_5595329);
             assert_eq!(result.lot.get_unchecked(underlying_1), 1_5395739);
             assert_eq!(result.lot.len(), 2);
+        });
+    }
+
+    #[test]
+    fn test_create_user_liquidation_auction_weird_scalar() {
+        let e = Env::default();
+
+        e.mock_all_auths();
+        e.ledger().set(LedgerInfo {
+            timestamp: 12345,
+            protocol_version: 20,
+            sequence_number: 50,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 10,
+            min_persistent_entry_ttl: 10,
+            max_entry_ttl: 2000000,
+        });
+
+        let bombadil = Address::generate(&e);
+        let samwise = Address::generate(&e);
+
+        let pool_address = create_pool(&e);
+        let (oracle_address, oracle_client) = testutils::create_mock_oracle(&e);
+
+        // creating reserves for a pool exhausts the budget
+        e.budget().reset_unlimited();
+        let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
+        let (mut reserve_config_0, mut reserve_data_0) = testutils::default_reserve_meta();
+        reserve_data_0.last_time = 12345;
+        reserve_data_0.b_rate = 1_000_206_159;
+        reserve_config_0.c_factor = 0_9000000;
+        reserve_config_0.l_factor = 0_9000000;
+        reserve_config_0.index = 0;
+        testutils::create_reserve(
+            &e,
+            &pool_address,
+            &underlying_0,
+            &reserve_config_0,
+            &reserve_data_0,
+        );
+
+        let (underlying_1, _) = testutils::create_token_contract(&e, &bombadil);
+        let (mut reserve_config_1, mut reserve_data_1) = testutils::default_reserve_meta();
+        reserve_data_1.b_rate = 1_200_000_000;
+        reserve_config_1.c_factor = 0_7500000;
+        reserve_config_1.l_factor = 0_7500000;
+        reserve_data_1.last_time = 12345;
+        reserve_config_1.index = 1;
+        testutils::create_reserve(
+            &e,
+            &pool_address,
+            &underlying_1,
+            &reserve_config_1,
+            &reserve_data_1,
+        );
+
+        let (underlying_2, _) = testutils::create_token_contract(&e, &bombadil);
+        let (mut reserve_config_2, mut reserve_data_2) = testutils::default_reserve_meta();
+        reserve_config_2.c_factor = 0_0000000;
+        reserve_config_2.l_factor = 0_9000000;
+        reserve_config_2.index = 2;
+        reserve_data_2.d_rate = 1000201748;
+        testutils::create_reserve(
+            &e,
+            &pool_address,
+            &underlying_2,
+            &reserve_config_2,
+            &reserve_data_2,
+        );
+
+        oracle_client.set_data(
+            &bombadil,
+            &Asset::Other(Symbol::new(&e, "USD")),
+            &vec![
+                &e,
+                Asset::Stellar(underlying_0.clone()),
+                Asset::Stellar(underlying_1.clone()),
+                Asset::Stellar(underlying_2.clone()),
+            ],
+            &14,
+            &300,
+        );
+        oracle_client.set_price_stable(&vec![
+            &e,
+            1418501_2444444,
+            1_0000000_00000000,
+            1_0261166_9700969,
+        ]);
+
+        let liq_pct = 69;
+        let positions: Positions = Positions {
+            collateral: map![&e, (reserve_config_0.index, 8999_1357639),],
+            liabilities: map![&e, (reserve_config_2.index, 1059_5526742),],
+            supply: map![&e],
+        };
+        let pool_config = PoolConfig {
+            oracle: oracle_address,
+            bstop_rate: 0_1000000,
+            status: 0,
+            max_positions: 4,
+        };
+        e.as_contract(&pool_address, || {
+            storage::set_user_positions(&e, &samwise, &positions);
+            storage::set_pool_config(&e, &pool_config);
+
+            e.budget().reset_unlimited();
+            let result = create_user_liq_auction_data(&e, &samwise, liq_pct);
+            println!("lot {:?}", result.lot);
+            println!("bid {:?}", result.bid);
+            // assert_eq!(result.block, 51);
+            // assert_eq!(result.bid.get_unchecked(underlying_2), 1_2375000);
+            // assert_eq!(result.bid.len(), 1);
+            // assert_eq!(result.lot.get_unchecked(underlying_0), 30_5595329);
+            // assert_eq!(result.lot.get_unchecked(underlying_1), 1_5395739);
+            // assert_eq!(result.lot.len(), 2);
+        });
+    }
+
+    #[test]
+    fn test_create_user_liquidation_auction_full_liquidation() {
+        let e = Env::default();
+
+        e.mock_all_auths();
+        e.ledger().set(LedgerInfo {
+            timestamp: 12345,
+            protocol_version: 20,
+            sequence_number: 50,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 10,
+            min_persistent_entry_ttl: 10,
+            max_entry_ttl: 2000000,
+        });
+
+        let bombadil = Address::generate(&e);
+        let samwise = Address::generate(&e);
+
+        let pool_address = create_pool(&e);
+        let (oracle_address, oracle_client) = testutils::create_mock_oracle(&e);
+
+        // creating reserves for a pool exhausts the budget
+        e.budget().reset_unlimited();
+        let (underlying_0, _) = testutils::create_token_contract(&e, &bombadil);
+        let (mut reserve_config_0, mut reserve_data_0) = testutils::default_reserve_meta();
+        reserve_data_0.last_time = 12345;
+        reserve_data_0.b_rate = 1_000_206_159;
+        reserve_config_0.c_factor = 0_9000000;
+        reserve_config_0.l_factor = 0_9000000;
+        reserve_config_0.index = 0;
+        testutils::create_reserve(
+            &e,
+            &pool_address,
+            &underlying_0,
+            &reserve_config_0,
+            &reserve_data_0,
+        );
+
+        let (underlying_2, _) = testutils::create_token_contract(&e, &bombadil);
+        let (mut reserve_config_2, mut reserve_data_2) = testutils::default_reserve_meta();
+        reserve_config_2.c_factor = 0_0000000;
+        reserve_config_2.l_factor = 0_9000000;
+        reserve_config_2.index = 2;
+        reserve_config_2.decimals = 6;
+        reserve_data_2.d_rate = 1000201748;
+        testutils::create_reserve(
+            &e,
+            &pool_address,
+            &underlying_2,
+            &reserve_config_2,
+            &reserve_data_2,
+        );
+
+        oracle_client.set_data(
+            &bombadil,
+            &Asset::Other(Symbol::new(&e, "USD")),
+            &vec![
+                &e,
+                Asset::Stellar(underlying_0.clone()),
+                Asset::Stellar(underlying_2.clone()),
+            ],
+            &3,
+            &300,
+        );
+        oracle_client.set_price_stable(&vec![&e, 100, 100]);
+
+        let liq_pct = 100;
+        let positions: Positions = Positions {
+            collateral: map![&e, (reserve_config_0.index, 8_000_0000),],
+            liabilities: map![&e, (reserve_config_2.index, 100_000_000),],
+            supply: map![&e],
+        };
+        let pool_config = PoolConfig {
+            oracle: oracle_address,
+            bstop_rate: 0_1000000,
+            status: 0,
+            max_positions: 4,
+        };
+        e.as_contract(&pool_address, || {
+            storage::set_user_positions(&e, &samwise, &positions);
+            storage::set_pool_config(&e, &pool_config);
+            println!("here");
+            e.budget().reset_unlimited();
+            let result = create_user_liq_auction_data(&e, &samwise, liq_pct);
+            println!("lot {:?}", result.lot);
+            println!("bid {:?}", result.bid);
+            // assert_eq!(result.block, 51);
+            // assert_eq!(result.bid.get_unchecked(underlying_2), 1_2375000);
+            // assert_eq!(result.bid.len(), 1);
+            // assert_eq!(result.lot.get_unchecked(underlying_0), 30_5595329);
+            // assert_eq!(result.lot.get_unchecked(underlying_1), 1_5395739);
+            // assert_eq!(result.lot.len(), 2);
         });
     }
 

--- a/pool/src/auctions/user_liquidation_auction.rs
+++ b/pool/src/auctions/user_liquidation_auction.rs
@@ -198,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_user_liquidation_auction() {
+    fn test_create_user_liquidation_auction_normal_scalars() {
         let e = Env::default();
 
         e.mock_all_auths();
@@ -569,10 +569,10 @@ mod tests {
                 Asset::Stellar(underlying_1),
                 Asset::Stellar(underlying_2),
             ],
-            &7,
+            &8,
             &300,
         );
-        oracle_client.set_price_stable(&vec![&e, 2_0000000, 4_0000000, 50_0000000]);
+        oracle_client.set_price_stable(&vec![&e, 2_0000000_0, 4_0000000_0, 50_0000000_0]);
 
         let liq_pct = 100;
         let pool_config = PoolConfig {
@@ -675,10 +675,10 @@ mod tests {
                 Asset::Stellar(underlying_1),
                 Asset::Stellar(underlying_2),
             ],
-            &7,
+            &6,
             &300,
         );
-        oracle_client.set_price_stable(&vec![&e, 2_0000000, 4_0000000, 50_0000000]);
+        oracle_client.set_price_stable(&vec![&e, 2_000000, 4_000000, 50_000000]);
 
         let liq_pct = 46;
         let pool_config = PoolConfig {
@@ -782,10 +782,10 @@ mod tests {
                 Asset::Stellar(underlying_1),
                 Asset::Stellar(underlying_2),
             ],
-            &7,
+            &5,
             &300,
         );
-        oracle_client.set_price_stable(&vec![&e, 2_0000000, 4_0000000, 50_0000000]);
+        oracle_client.set_price_stable(&vec![&e, 2_00000, 4_00000, 50_00000]);
 
         let liq_pct = 25;
         let pool_config = PoolConfig {

--- a/pool/src/pool/submit.rs
+++ b/pool/src/pool/submit.rs
@@ -40,8 +40,9 @@ pub fn execute_submit(
 
     if check_health {
         // panics if the new positions set does not meet the health factor requirement
+        // min is 1.0000100 to prevent rounding errors
         PositionData::calculate_from_positions(e, &mut pool, &new_from_state.positions)
-            .require_healthy(e);
+            .require_hf_over(e, 1_0000100, PoolError::InvalidHf);
     }
 
     // transfer tokens from sender to pool

--- a/pool/src/pool/submit.rs
+++ b/pool/src/pool/submit.rs
@@ -41,8 +41,8 @@ pub fn execute_submit(
     // panics if the new positions set does not meet the health factor requirement
     // min is 1.0000100 to prevent rounding errors
     if check_health
-        && !PositionData::calculate_from_positions(e, &mut pool, &new_from_state.positions)
-            .require_hf_over(1_0000100)
+        && PositionData::calculate_from_positions(e, &mut pool, &new_from_state.positions)
+            .is_hf_under(1_0000100)
     {
         panic_with_error!(e, PoolError::InvalidHf);
     }

--- a/pool/src/pool/submit.rs
+++ b/pool/src/pool/submit.rs
@@ -38,11 +38,13 @@ pub fn execute_submit(
     let (actions, new_from_state, check_health) =
         build_actions_from_request(e, &mut pool, from, requests);
 
-    if check_health {
-        // panics if the new positions set does not meet the health factor requirement
-        // min is 1.0000100 to prevent rounding errors
-        PositionData::calculate_from_positions(e, &mut pool, &new_from_state.positions)
-            .require_hf_over(e, 1_0000100, PoolError::InvalidHf);
+    // panics if the new positions set does not meet the health factor requirement
+    // min is 1.0000100 to prevent rounding errors
+    if check_health
+        && !PositionData::calculate_from_positions(e, &mut pool, &new_from_state.positions)
+            .require_hf_over(1_0000100)
+    {
+        panic_with_error!(e, PoolError::InvalidHf);
     }
 
     // transfer tokens from sender to pool


### PR DESCRIPTION
Fixed a bug with scalar handling in liquidation auction creation

Also removed .require_healthy() from health_factor.rs in favor of require_hf_above and require_hf_below to concentrate all health factor checks there