### PR TITLE
Set base rate

### DIFF
--- a/pool/src/contract.rs
+++ b/pool/src/contract.rs
@@ -312,7 +312,7 @@ impl Pool for PoolContract {
     }
 
     fn set_reserve(e: Env, asset: Address) -> u32 {
-        let index = pool::execute_set_queued_reserve(&e, &asset);
+        let index = pool::execute_set_reserve(&e, &asset);
 
         e.events()
             .publish((Symbol::new(&e, "set_reserve"),), (asset, index));

--- a/pool/src/pool/config.rs
+++ b/pool/src/pool/config.rs
@@ -95,7 +95,7 @@ pub fn execute_cancel_queued_set_reserve(e: &Env, asset: &Address) {
 }
 
 /// Execute a queued reserve initialization for the pool
-pub fn execute_set_queued_reserve(e: &Env, asset: &Address) -> u32 {
+pub fn execute_set_reserve(e: &Env, asset: &Address) -> u32 {
     let queued_init = storage::get_queued_reserve_set(e, asset);
 
     if queued_init.unlock_time > e.ledger().timestamp() {
@@ -125,7 +125,8 @@ fn initialize_reserve(e: &Env, asset: &Address, config: &ReserveConfig) -> u32 {
             panic_with_error!(e, PoolError::InvalidReserveMetadata);
         }
         // if any of the IR parameters were changed reset the IR modifier
-        if reserve_config.r_one != config.r_one
+        if reserve_config.r_base != config.r_base
+            || reserve_config.r_one != config.r_one
             || reserve_config.r_two != config.r_two
             || reserve_config.r_three != config.r_three
             || reserve_config.util != config.util
@@ -154,6 +155,7 @@ fn initialize_reserve(e: &Env, asset: &Address, config: &ReserveConfig) -> u32 {
         l_factor: config.l_factor,
         util: config.util,
         max_util: config.max_util,
+        r_base: config.r_base,
         r_one: config.r_one,
         r_two: config.r_two,
         r_three: config.r_three,
@@ -172,6 +174,8 @@ fn require_valid_reserve_metadata(e: &Env, metadata: &ReserveConfig) {
         || metadata.l_factor > SCALAR_7_U32
         || metadata.util > 0_9500000
         || (metadata.max_util > SCALAR_7_U32 || metadata.max_util <= metadata.util)
+        || metadata.r_base >= 1_0000000
+        || metadata.r_base < 0_0001000
         || (metadata.r_one > metadata.r_two || metadata.r_two > metadata.r_three)
         || (metadata.reactivity > 0_0001000)
     {
@@ -371,7 +375,7 @@ mod tests {
     }
 
     #[test]
-    fn test_queue_initial_reserve() {
+    fn test_queue_set_reserve_status_6() {
         let e = Env::default();
         let pool = testutils::create_pool(&e);
         let bombadil = Address::generate(&e);
@@ -385,6 +389,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0100000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -401,22 +406,23 @@ mod tests {
             execute_queue_set_reserve(&e, &asset_id_0, &metadata);
             let queued_res = storage::get_queued_reserve_set(&e, &asset_id_0);
             let res_config_0 = queued_res.new_config;
-            assert_eq!(queued_res.unlock_time, e.ledger().timestamp());
             assert_eq!(res_config_0.decimals, metadata.decimals);
             assert_eq!(res_config_0.c_factor, metadata.c_factor);
             assert_eq!(res_config_0.l_factor, metadata.l_factor);
             assert_eq!(res_config_0.util, metadata.util);
-            assert_eq!(res_config_0.max_util, metadata.max_util);
+            assert_eq!(res_config_0.r_base, metadata.r_base);
+            assert_eq!(res_config_0.r_one, metadata.r_one);
             assert_eq!(res_config_0.r_one, metadata.r_one);
             assert_eq!(res_config_0.r_two, metadata.r_two);
             assert_eq!(res_config_0.r_three, metadata.r_three);
             assert_eq!(res_config_0.reactivity, metadata.reactivity);
             assert_eq!(res_config_0.index, 0);
+            assert_eq!(queued_res.unlock_time, e.ledger().timestamp());
         });
     }
 
     #[test]
-    fn test_execute_queue_reserve_initialization() {
+    fn test_queue_set_reserve() {
         let e = Env::default();
         let pool = testutils::create_pool(&e);
         let bombadil = Address::generate(&e);
@@ -430,6 +436,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0100000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -450,6 +457,7 @@ mod tests {
             assert_eq!(queued_init.new_config.l_factor, metadata.l_factor);
             assert_eq!(queued_init.new_config.util, metadata.util);
             assert_eq!(queued_init.new_config.max_util, metadata.max_util);
+            assert_eq!(queued_init.new_config.r_base, metadata.r_base);
             assert_eq!(queued_init.new_config.r_one, metadata.r_one);
             assert_eq!(queued_init.new_config.r_two, metadata.r_two);
             assert_eq!(queued_init.new_config.r_three, metadata.r_three);
@@ -464,7 +472,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "Error(Contract, #1200)")]
-    fn test_queue_reserve_duplicate() {
+    fn test_queue_set_reserve_duplicate() {
         let e = Env::default();
         let pool = testutils::create_pool(&e);
         let bombadil = Address::generate(&e);
@@ -478,6 +486,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0100000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -502,6 +511,39 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "Error(Contract, #1202)")]
+    fn test_queue_set_reserve_validates_metadata() {
+        let e = Env::default();
+        let pool = testutils::create_pool(&e);
+        let bombadil = Address::generate(&e);
+        let (asset_id, _) = testutils::create_token_contract(&e, &bombadil);
+
+        let metadata = ReserveConfig {
+            index: 0,
+            decimals: 7,
+            c_factor: 0_7500000,
+            l_factor: 1_7500000,
+            util: 1_0000000,
+            max_util: 0_9500000,
+            r_base: 0_0100000,
+            r_one: 0_0500000,
+            r_two: 0_5000000,
+            r_three: 1_5000000,
+            reactivity: 100,
+        };
+        let pool_config = PoolConfig {
+            oracle: Address::generate(&e),
+            bstop_rate: 0_1000000,
+            status: 0,
+            max_positions: 2,
+        };
+        e.as_contract(&pool, || {
+            storage::set_pool_config(&e, &pool_config);
+            execute_queue_set_reserve(&e, &asset_id, &metadata);
+        });
+    }
+
+    #[test]
     fn test_execute_cancel_queued_reserve_initialization() {
         let e = Env::default();
         let pool = testutils::create_pool(&e);
@@ -516,6 +558,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0100000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -538,7 +581,7 @@ mod tests {
     }
 
     #[test]
-    fn test_execute_initialize_queued_reserve() {
+    fn test_execute_set_reserve_first_reserve() {
         let e = Env::default();
         let pool = testutils::create_pool(&e);
         let bombadil = Address::generate(&e);
@@ -552,6 +595,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0100000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -566,7 +610,7 @@ mod tests {
                 },
                 &asset_id_0,
             );
-            execute_set_queued_reserve(&e, &asset_id_0);
+            execute_set_reserve(&e, &asset_id_0);
             let res_config_0: ReserveConfig = storage::get_res_config(&e, &asset_id_0);
             assert_eq!(res_config_0.decimals, metadata.decimals);
             assert_eq!(res_config_0.c_factor, metadata.c_factor);
@@ -580,9 +624,10 @@ mod tests {
             assert_eq!(res_config_0.index, 0);
         });
     }
+
     #[test]
     #[should_panic(expected = "Error(Contract, #1203)")]
-    fn test_execute_queued_initialize_reserve_requires_block_passed() {
+    fn test_execute_set_reserve_requires_block_passed() {
         let e = Env::default();
         let pool = testutils::create_pool(&e);
         let bombadil = Address::generate(&e);
@@ -596,6 +641,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0100000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -610,11 +656,227 @@ mod tests {
                 },
                 &asset_id_0,
             );
-            execute_set_queued_reserve(&e, &asset_id_0);
+            execute_set_reserve(&e, &asset_id_0);
         });
     }
+
     #[test]
-    fn test_initialize_reserve() {
+    fn test_execute_set_reserve_update() {
+        let e = Env::default();
+        e.mock_all_auths();
+        e.ledger().set(LedgerInfo {
+            timestamp: 500,
+            protocol_version: 20,
+            sequence_number: 100,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 10,
+            min_persistent_entry_ttl: 10,
+            max_entry_ttl: 2000000,
+        });
+
+        let pool = testutils::create_pool(&e);
+        let bombadil = Address::generate(&e);
+
+        let (underlying, _) = testutils::create_token_contract(&e, &bombadil);
+        let (reserve_config, mut reserve_data) = testutils::default_reserve_meta();
+        reserve_data.ir_mod = 1_001_000_000;
+        testutils::create_reserve(&e, &pool, &underlying, &reserve_config, &reserve_data);
+
+        let mut new_metadata = reserve_config.clone();
+        new_metadata.index = 123;
+        new_metadata.c_factor += 1;
+        new_metadata.l_factor += 1;
+        new_metadata.max_util += 1;
+        new_metadata.reactivity += 1;
+
+        e.ledger().set(LedgerInfo {
+            timestamp: 10000,
+            protocol_version: 20,
+            sequence_number: 100,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 10,
+            min_persistent_entry_ttl: 10,
+            max_entry_ttl: 2000000,
+        });
+
+        let pool_config = PoolConfig {
+            oracle: Address::generate(&e),
+            bstop_rate: 0_1000000,
+            status: 0,
+            max_positions: 2,
+        };
+        e.as_contract(&pool, || {
+            storage::set_pool_config(&e, &pool_config);
+
+            storage::set_queued_reserve_set(
+                &e,
+                &QueuedReserveInit {
+                    new_config: new_metadata.clone(),
+                    unlock_time: e.ledger().timestamp(),
+                },
+                &underlying,
+            );
+            execute_set_reserve(&e, &underlying);
+            let res_config_updated = storage::get_res_config(&e, &underlying);
+            assert_eq!(res_config_updated.decimals, new_metadata.decimals);
+            assert_eq!(res_config_updated.c_factor, new_metadata.c_factor);
+            assert_eq!(res_config_updated.l_factor, new_metadata.l_factor);
+            assert_eq!(res_config_updated.util, new_metadata.util);
+            assert_eq!(res_config_updated.max_util, new_metadata.max_util);
+            assert_eq!(res_config_updated.r_base, new_metadata.r_base);
+            assert_eq!(res_config_updated.r_one, new_metadata.r_one);
+            assert_eq!(res_config_updated.r_two, new_metadata.r_two);
+            assert_eq!(res_config_updated.r_three, new_metadata.r_three);
+            assert_eq!(res_config_updated.reactivity, new_metadata.reactivity);
+            assert_eq!(res_config_updated.index, reserve_config.index);
+
+            // validate interest was accrued
+            let res_data = storage::get_res_data(&e, &underlying);
+            assert!(res_data.d_rate > 1_000_000_000);
+            assert!(res_data.backstop_credit > 0);
+            assert_eq!(res_data.last_time, 10000);
+            assert!(res_data.ir_mod != 1_000_000_000);
+        });
+    }
+
+    #[test]
+    fn test_execute_set_reserve_update_resets_ir_mod() {
+        let e = Env::default();
+        e.mock_all_auths();
+        e.ledger().set(LedgerInfo {
+            timestamp: 500,
+            protocol_version: 20,
+            sequence_number: 100,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 10,
+            min_persistent_entry_ttl: 10,
+            max_entry_ttl: 2000000,
+        });
+
+        let pool = testutils::create_pool(&e);
+        let bombadil = Address::generate(&e);
+
+        let (underlying, _) = testutils::create_token_contract(&e, &bombadil);
+        let (reserve_config, mut reserve_data) = testutils::default_reserve_meta();
+        reserve_data.ir_mod = 1_100_000_000;
+        testutils::create_reserve(&e, &pool, &underlying, &reserve_config, &reserve_data);
+
+        let mut new_metadata = reserve_config.clone();
+        new_metadata.r_base += 1;
+
+        e.ledger().set(LedgerInfo {
+            timestamp: 10000,
+            protocol_version: 20,
+            sequence_number: 100,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 10,
+            min_persistent_entry_ttl: 10,
+            max_entry_ttl: 2000000,
+        });
+
+        let pool_config = PoolConfig {
+            oracle: Address::generate(&e),
+            bstop_rate: 0_1000000,
+            status: 0,
+            max_positions: 2,
+        };
+        e.as_contract(&pool, || {
+            storage::set_pool_config(&e, &pool_config);
+
+            storage::set_queued_reserve_set(
+                &e,
+                &QueuedReserveInit {
+                    new_config: new_metadata.clone(),
+                    unlock_time: e.ledger().timestamp(),
+                },
+                &underlying,
+            );
+            execute_set_reserve(&e, &underlying);
+            let res_config_updated = storage::get_res_config(&e, &underlying);
+            assert_eq!(res_config_updated.decimals, new_metadata.decimals);
+            assert_eq!(res_config_updated.c_factor, new_metadata.c_factor);
+            assert_eq!(res_config_updated.l_factor, new_metadata.l_factor);
+            assert_eq!(res_config_updated.util, new_metadata.util);
+            assert_eq!(res_config_updated.max_util, new_metadata.max_util);
+            assert_eq!(res_config_updated.r_base, new_metadata.r_base);
+            assert_eq!(res_config_updated.r_one, new_metadata.r_one);
+            assert_eq!(res_config_updated.r_two, new_metadata.r_two);
+            assert_eq!(res_config_updated.r_three, new_metadata.r_three);
+            assert_eq!(res_config_updated.reactivity, new_metadata.reactivity);
+            assert_eq!(res_config_updated.index, reserve_config.index);
+
+            let res_data = storage::get_res_data(&e, &underlying);
+            assert!(res_data.d_rate > 1_000_000_000);
+            assert!(res_data.backstop_credit > 0);
+            assert_eq!(res_data.last_time, 10000);
+            assert_eq!(res_data.ir_mod, 1_000_000_000);
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #1202)")]
+    fn test_execute_set_reserve_validates_decimals_stay_same() {
+        let e = Env::default();
+        e.mock_all_auths();
+        e.ledger().set(LedgerInfo {
+            timestamp: 500,
+            protocol_version: 20,
+            sequence_number: 100,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 10,
+            min_persistent_entry_ttl: 10,
+            max_entry_ttl: 2000000,
+        });
+
+        let pool = testutils::create_pool(&e);
+        let bombadil = Address::generate(&e);
+
+        let (underlying, _) = testutils::create_token_contract(&e, &bombadil);
+        let (reserve_config, reserve_data) = testutils::default_reserve_meta();
+        testutils::create_reserve(&e, &pool, &underlying, &reserve_config, &reserve_data);
+
+        let new_metadata = ReserveConfig {
+            index: 99,
+            decimals: 8, // started at 18
+            c_factor: 0_7500000,
+            l_factor: 0_7500000,
+            util: 0_0777777,
+            max_util: 0_9500000,
+            r_base: 0_0100000,
+            r_one: 0_0500000,
+            r_two: 0_5000000,
+            r_three: 1_5000000,
+            reactivity: 105,
+        };
+
+        let pool_config = PoolConfig {
+            oracle: Address::generate(&e),
+            bstop_rate: 0_1000000,
+            status: 0,
+            max_positions: 2,
+        };
+        e.as_contract(&pool, || {
+            storage::set_pool_config(&e, &pool_config);
+
+            storage::set_queued_reserve_set(
+                &e,
+                &QueuedReserveInit {
+                    new_config: new_metadata.clone(),
+                    unlock_time: e.ledger().timestamp(),
+                },
+                &underlying,
+            );
+            execute_set_reserve(&e, &underlying);
+        });
+    }
+
+    #[test]
+    fn test_initialize_reserve_sets_index() {
         let e = Env::default();
         let pool = testutils::create_pool(&e);
         let bombadil = Address::generate(&e);
@@ -629,6 +891,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0100000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -655,238 +918,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Error(Contract, #1202)")]
-    fn test_queue_set_reserve_validates_metadata() {
-        let e = Env::default();
-        let pool = testutils::create_pool(&e);
-        let bombadil = Address::generate(&e);
-        let (asset_id, _) = testutils::create_token_contract(&e, &bombadil);
-
-        let metadata = ReserveConfig {
-            index: 0,
-            decimals: 7,
-            c_factor: 0_7500000,
-            l_factor: 1_7500000,
-            util: 1_0000000,
-            max_util: 0_9500000,
-            r_one: 0_0500000,
-            r_two: 0_5000000,
-            r_three: 1_5000000,
-            reactivity: 100,
-        };
-        let pool_config = PoolConfig {
-            oracle: Address::generate(&e),
-            bstop_rate: 0_1000000,
-            status: 0,
-            max_positions: 2,
-        };
-        e.as_contract(&pool, || {
-            storage::set_pool_config(&e, &pool_config);
-            execute_queue_set_reserve(&e, &asset_id, &metadata);
-        });
-    }
-
-    #[test]
-    fn test_execute_update_reserve() {
-        let e = Env::default();
-        e.mock_all_auths();
-        e.ledger().set(LedgerInfo {
-            timestamp: 500,
-            protocol_version: 20,
-            sequence_number: 100,
-            network_id: Default::default(),
-            base_reserve: 10,
-            min_temp_entry_ttl: 10,
-            min_persistent_entry_ttl: 10,
-            max_entry_ttl: 2000000,
-        });
-
-        let pool = testutils::create_pool(&e);
-        let bombadil = Address::generate(&e);
-
-        let (underlying, _) = testutils::create_token_contract(&e, &bombadil);
-        let (reserve_config, reserve_data) = testutils::default_reserve_meta();
-        testutils::create_reserve(&e, &pool, &underlying, &reserve_config, &reserve_data);
-
-        let new_metadata = ReserveConfig {
-            index: 99,
-            decimals: 7,
-            c_factor: 0_7500000,
-            l_factor: 0_7500000,
-            util: 0_7777777,
-            max_util: 0_9500000,
-            r_one: 0_0500000,
-            r_two: 0_5000000,
-            r_three: 1_5000000,
-            reactivity: 105,
-        };
-
-        e.ledger().set(LedgerInfo {
-            timestamp: 10000,
-            protocol_version: 20,
-            sequence_number: 100,
-            network_id: Default::default(),
-            base_reserve: 10,
-            min_temp_entry_ttl: 10,
-            min_persistent_entry_ttl: 10,
-            max_entry_ttl: 2000000,
-        });
-
-        let pool_config = PoolConfig {
-            oracle: Address::generate(&e),
-            bstop_rate: 0_1000000,
-            status: 0,
-            max_positions: 2,
-        };
-        e.as_contract(&pool, || {
-            storage::set_pool_config(&e, &pool_config);
-
-            let res_config_old = storage::get_res_config(&e, &underlying);
-            storage::set_queued_reserve_set(
-                &e,
-                &QueuedReserveInit {
-                    new_config: new_metadata.clone(),
-                    unlock_time: e.ledger().timestamp(),
-                },
-                &underlying,
-            );
-            execute_set_queued_reserve(&e, &underlying);
-            let res_config_updated = storage::get_res_config(&e, &underlying);
-            assert_eq!(res_config_updated.decimals, new_metadata.decimals);
-            assert_eq!(res_config_updated.c_factor, new_metadata.c_factor);
-            assert_eq!(res_config_updated.l_factor, new_metadata.l_factor);
-            assert_eq!(res_config_updated.util, new_metadata.util);
-            assert_eq!(res_config_updated.max_util, new_metadata.max_util);
-            assert_eq!(res_config_updated.r_one, new_metadata.r_one);
-            assert_eq!(res_config_updated.r_two, new_metadata.r_two);
-            assert_eq!(res_config_updated.r_three, new_metadata.r_three);
-            assert_eq!(res_config_updated.reactivity, new_metadata.reactivity);
-            assert_eq!(res_config_updated.index, res_config_old.index);
-
-            // validate interest was accrued
-            let res_data = storage::get_res_data(&e, &underlying);
-            assert!(res_data.d_rate > 1_000_000_000);
-            assert!(res_data.backstop_credit > 0);
-            assert_eq!(res_data.last_time, 10000);
-        });
-    }
-
-    #[test]
-    #[should_panic(expected = "Error(Contract, #1202)")]
-    fn test_execute_update_reserve_validates_decimals() {
-        let e = Env::default();
-        e.mock_all_auths();
-        e.ledger().set(LedgerInfo {
-            timestamp: 500,
-            protocol_version: 20,
-            sequence_number: 100,
-            network_id: Default::default(),
-            base_reserve: 10,
-            min_temp_entry_ttl: 10,
-            min_persistent_entry_ttl: 10,
-            max_entry_ttl: 2000000,
-        });
-
-        let pool = testutils::create_pool(&e);
-        let bombadil = Address::generate(&e);
-
-        let (underlying, _) = testutils::create_token_contract(&e, &bombadil);
-        let (reserve_config, reserve_data) = testutils::default_reserve_meta();
-        testutils::create_reserve(&e, &pool, &underlying, &reserve_config, &reserve_data);
-
-        let new_metadata = ReserveConfig {
-            index: 99,
-            decimals: 8,
-            c_factor: 0_7500000,
-            l_factor: 0_7500000,
-            util: 1_0777777,
-            max_util: 0_9500000,
-            r_one: 0_0500000,
-            r_two: 0_5000000,
-            r_three: 1_5000000,
-            reactivity: 105,
-        };
-
-        let pool_config = PoolConfig {
-            oracle: Address::generate(&e),
-            bstop_rate: 0_1000000,
-            status: 0,
-            max_positions: 2,
-        };
-        e.as_contract(&pool, || {
-            storage::set_pool_config(&e, &pool_config);
-
-            storage::set_queued_reserve_set(
-                &e,
-                &QueuedReserveInit {
-                    new_config: new_metadata.clone(),
-                    unlock_time: e.ledger().timestamp(),
-                },
-                &underlying,
-            );
-            execute_set_queued_reserve(&e, &underlying);
-        });
-    }
-
-    #[test]
-    fn test_execute_update_reserve_resets_ir_mod() {
-        let e = Env::default();
-        e.mock_all_auths();
-        e.ledger().set(LedgerInfo {
-            timestamp: 500,
-            protocol_version: 20,
-            sequence_number: 100,
-            network_id: Default::default(),
-            base_reserve: 10,
-            min_temp_entry_ttl: 10,
-            min_persistent_entry_ttl: 10,
-            max_entry_ttl: 2000000,
-        });
-
-        let pool = testutils::create_pool(&e);
-        let bombadil = Address::generate(&e);
-
-        let (underlying, _) = testutils::create_token_contract(&e, &bombadil);
-        let (reserve_config, reserve_data) = testutils::default_reserve_meta();
-        testutils::create_reserve(&e, &pool, &underlying, &reserve_config, &reserve_data);
-
-        let new_metadata = ReserveConfig {
-            index: 99,
-            decimals: 7,
-            c_factor: 0_7500000,
-            l_factor: 0_7500000,
-            util: 1_0777777,
-            max_util: 0_9500000,
-            r_one: 0_0500000,
-            r_two: 0_7500000,
-            r_three: 1_5000000,
-            reactivity: 105,
-        };
-
-        let pool_config = PoolConfig {
-            oracle: Address::generate(&e),
-            bstop_rate: 0_1000000,
-            status: 0,
-            max_positions: 2,
-        };
-        e.as_contract(&pool, || {
-            storage::set_pool_config(&e, &pool_config);
-
-            storage::set_queued_reserve_set(
-                &e,
-                &QueuedReserveInit {
-                    new_config: new_metadata.clone(),
-                    unlock_time: e.ledger().timestamp(),
-                },
-                &underlying,
-            );
-            execute_set_queued_reserve(&e, &underlying);
-            let res_data = storage::get_res_data(&e, &underlying);
-            assert_eq!(res_data.ir_mod, 1_000_000_000);
-        });
-    }
-
-    #[test]
     fn test_validate_reserve_metadata() {
         let e = Env::default();
 
@@ -898,6 +929,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0001000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -920,6 +952,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0001000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -940,6 +973,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0001000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -960,6 +994,7 @@ mod tests {
             l_factor: 1_0000001,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0001000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -980,6 +1015,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 1_0000000,
             max_util: 0_9500000,
+            r_base: 0_0001000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -1000,6 +1036,49 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 1_0000001,
+            r_base: 0_0001000,
+            r_one: 0_0500000,
+            r_two: 0_5000000,
+            r_three: 1_5000000,
+            reactivity: 100,
+        };
+        require_valid_reserve_metadata(&e, &metadata);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #1202)")]
+    fn test_validate_reserve_metadata_validates_r_base_too_high() {
+        let e = Env::default();
+
+        let metadata = ReserveConfig {
+            index: 0,
+            decimals: 18,
+            c_factor: 0_7500000,
+            l_factor: 0_7500000,
+            util: 0_5000000,
+            max_util: 0_9500000,
+            r_base: 1_0000000,
+            r_one: 0_0500000,
+            r_two: 0_5000000,
+            r_three: 1_5000000,
+            reactivity: 100,
+        };
+        require_valid_reserve_metadata(&e, &metadata);
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #1202)")]
+    fn test_validate_reserve_metadata_validates_r_base_too_low() {
+        let e = Env::default();
+
+        let metadata = ReserveConfig {
+            index: 0,
+            decimals: 18,
+            c_factor: 0_7500000,
+            l_factor: 0_7500000,
+            util: 0_5000000,
+            max_util: 0_9500000,
+            r_base: 0_0000999,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -1020,6 +1099,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0000100,
             r_one: 0_5000001,
             r_two: 0_5000000,
             r_three: 1_5000000,
@@ -1040,6 +1120,7 @@ mod tests {
             l_factor: 0_7500000,
             util: 0_5000000,
             max_util: 0_9500000,
+            r_base: 0_0100000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,

--- a/pool/src/pool/mod.rs
+++ b/pool/src/pool/mod.rs
@@ -7,7 +7,7 @@ pub use bad_debt::transfer_bad_debt_to_backstop;
 mod config;
 pub use config::{
     execute_cancel_queued_set_reserve, execute_initialize, execute_queue_set_reserve,
-    execute_set_queued_reserve, execute_update_pool,
+    execute_set_reserve, execute_update_pool,
 };
 
 mod health_factor;

--- a/pool/src/pool/reserve.rs
+++ b/pool/src/pool/reserve.rs
@@ -70,6 +70,12 @@ impl Reserve {
         }
 
         let cur_util = reserve.utilization();
+        if cur_util == 0 {
+            // if there are no assets borrowed, we don't need to update the reserve
+            reserve.last_time = e.ledger().timestamp();
+            return reserve;
+        }
+
         let (loan_accrual, new_ir_mod) = calc_accrual(
             e,
             &reserve_config,
@@ -86,20 +92,22 @@ impl Reserve {
             .fixed_mul_ceil(reserve.d_rate, SCALAR_9)
             .unwrap_optimized();
 
-        // credit the backstop underlying from the accrued interest based on the backstop rate
-        // update the accrued interest to reflect the amount the pool accrued
         let accrued_interest = reserve.total_liabilities() - pre_update_liabilities;
-        let mut new_backstop_credit: i128 = 0;
-        if pool_config.bstop_rate > 0 && accrued_interest > 0 {
-            new_backstop_credit = accrued_interest
-                .fixed_mul_floor(i128(pool_config.bstop_rate), SCALAR_7)
+        if accrued_interest > 0 {
+            // credit the backstop underlying from the accrued interest based on the backstop rate
+            // update the accrued interest to reflect the amount the pool accrued
+            let mut new_backstop_credit: i128 = 0;
+            if pool_config.bstop_rate > 0 {
+                new_backstop_credit = accrued_interest
+                    .fixed_mul_floor(i128(pool_config.bstop_rate), SCALAR_7)
+                    .unwrap_optimized();
+                reserve.backstop_credit += new_backstop_credit;
+            }
+            reserve.b_rate = (pre_update_supply + accrued_interest - new_backstop_credit)
+                .fixed_div_floor(reserve.b_supply, SCALAR_9)
                 .unwrap_optimized();
-            reserve.backstop_credit += new_backstop_credit;
         }
 
-        reserve.b_rate = (pre_update_supply + accrued_interest - new_backstop_credit)
-            .fixed_div_floor(reserve.b_supply, SCALAR_9)
-            .unwrap_optimized();
         reserve.last_time = e.ledger().timestamp();
         reserve
     }
@@ -328,6 +336,52 @@ mod tests {
             assert_eq!(reserve.ir_mod, 1_000_000_000);
             assert_eq!(reserve.d_supply, 0);
             assert_eq!(reserve.b_supply, 0);
+            assert_eq!(reserve.backstop_credit, 0);
+            assert_eq!(reserve.last_time, 617280);
+        });
+    }
+
+    #[test]
+    fn test_load_reserve_zero_util() {
+        let e = Env::default();
+        e.mock_all_auths();
+
+        e.ledger().set(LedgerInfo {
+            timestamp: 123456 * 5,
+            protocol_version: 20,
+            sequence_number: 123456,
+            network_id: Default::default(),
+            base_reserve: 10,
+            min_temp_entry_ttl: 10,
+            min_persistent_entry_ttl: 10,
+            max_entry_ttl: 2000000,
+        });
+
+        let bombadil = Address::generate(&e);
+        let pool = testutils::create_pool(&e);
+        let oracle = Address::generate(&e);
+
+        let (underlying, _) = testutils::create_token_contract(&e, &bombadil);
+        let (reserve_config, mut reserve_data) = testutils::default_reserve_meta();
+        reserve_data.d_rate = 0;
+        reserve_data.d_supply = 0;
+        testutils::create_reserve(&e, &pool, &underlying, &reserve_config, &reserve_data);
+
+        let pool_config = PoolConfig {
+            oracle,
+            bstop_rate: 0_2000000,
+            status: 0,
+            max_positions: 4,
+        };
+        e.as_contract(&pool, || {
+            storage::set_pool_config(&e, &pool_config);
+            let reserve = Reserve::load(&e, &pool_config, &underlying);
+
+            assert_eq!(reserve.d_rate, 0);
+            assert_eq!(reserve.b_rate, reserve_data.b_rate);
+            assert_eq!(reserve.ir_mod, reserve_data.ir_mod);
+            assert_eq!(reserve.d_supply, 0);
+            assert_eq!(reserve.b_supply, reserve_data.b_supply);
             assert_eq!(reserve.backstop_credit, 0);
             assert_eq!(reserve.last_time, 617280);
         });

--- a/pool/src/storage.rs
+++ b/pool/src/storage.rs
@@ -41,9 +41,10 @@ pub struct ReserveConfig {
     pub l_factor: u32,   // the liability factor for the reserve scaled expressed in 7 decimals
     pub util: u32,       // the target utilization rate scaled expressed in 7 decimals
     pub max_util: u32,   // the maximum allowed utilization rate scaled expressed in 7 decimals
-    pub r_one: u32,      // the R1 value in the interest rate formula scaled expressed in 7 decimals
-    pub r_two: u32,      // the R2 value in the interest rate formula scaled expressed in 7 decimals
-    pub r_three: u32,    // the R3 value in the interest rate formula scaled expressed in 7 decimals
+    pub r_base: u32, // the R0 value (base rate) in the interest rate formula scaled expressed in 7 decimals
+    pub r_one: u32,  // the R1 value in the interest rate formula scaled expressed in 7 decimals
+    pub r_two: u32,  // the R2 value in the interest rate formula scaled expressed in 7 decimals
+    pub r_three: u32, // the R3 value in the interest rate formula scaled expressed in 7 decimals
     pub reactivity: u32, // the reactivity constant for the reserve scaled expressed in 7 decimals
 }
 

--- a/pool/src/testutils.rs
+++ b/pool/src/testutils.rs
@@ -208,6 +208,7 @@ pub(crate) fn default_reserve_meta() -> (ReserveConfig, ReserveData) {
             l_factor: 0_7500000,
             util: 0_7500000,
             max_util: 0_9500000,
+            r_base: 0_0100000,
             r_one: 0_0500000,
             r_two: 0_5000000,
             r_three: 1_5000000,

--- a/test-suites/src/pool.rs
+++ b/test-suites/src/pool.rs
@@ -12,6 +12,7 @@ pub fn default_reserve_metadata() -> ReserveConfig {
         l_factor: 0_7500000,
         util: 0_7500000,
         max_util: 0_9500000,
+        r_base: 0_0100000,
         r_one: 0_0500000,
         r_two: 0_5000000,
         r_three: 1_5000000,

--- a/test-suites/tests/test_backstop_inflation_attack.rs
+++ b/test-suites/tests/test_backstop_inflation_attack.rs
@@ -6,8 +6,8 @@ use test_suites::{
     test_fixture::{TestFixture, TokenIndex, SCALAR_7},
 };
 
-// This test showcases an inflation attack during a backstops initialization stage. This is a 
-// high risk inflation attack for the attacker, and requires significant capital to execute. 
+// This test showcases an inflation attack during a backstops initialization stage. This is a
+// high risk inflation attack for the attacker, and requires significant capital to execute.
 // If the donation does not happen before the victim deposits, the attacker will lose the majority
 // of the capital they donated to the backstop.
 //


### PR DESCRIPTION
* specify the base rate (`r_base`) in the reserve config, allowing things like fixed rates to be configured clearly
* stop the interest rate modifier from being adjusted when utilization is zero